### PR TITLE
feat: PHP 8 modernization, security hardening, and full unit test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop, master ]
+  pull_request:
+    branches: [ develop, master ]
+
+jobs:
+  test:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ "8.1", "8.2", "8.3" ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: ./vendor/bin/phpunit --colors=never

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "wink/wink-wordpress-plugin",
+    "description": "Wink Affiliate WordPress Plugin",
+    "type": "wordpress-plugin",
+    "license": "GPL-3.0",
+    "require": {
+        "php": ">=8.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5",
+        "brain/monkey": "^2.6",
+        "mockery/mockery": "^1.6"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Wink\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit --configuration phpunit.xml"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1942 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "29eb7fba95fbb318c373ee63a47bd3a0",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "~1.3.6 || ~1.4.4 || ~1.5.1 || ^1.6.10",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.49 || ^9.6.30"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/api.php"
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
+                "source": "https://github.com/Brain-WP/BrainMonkey"
+            },
+            "time": "2026-02-05T09:22:14+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.63",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.5",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:48:37+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:25:16+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.0"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/includes/WinkApiClient.php
+++ b/includes/WinkApiClient.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Wink API client — handles all communication with the Wink.travel REST APIs.
+ *
+ * Responsibilities:
+ *   1. Acquiring an OAuth2 bearer token from the Wink IAM server.
+ *   2. Caching that token via the WordPress Transients API so it is not
+ *      re-fetched on every page load.
+ *   3. Fetching the affiliate's saved layout list from the Wink REST API.
+ *   4. Caching the layout list for WINK_CACHE_TTL seconds.
+ *
+ * This class intentionally does NOT render any HTML. Rendering is the
+ * responsibility of winkContent (includes/elements/winkcontent.php).
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class WinkApiClient {
+    /** Transient key used to cache the OAuth2 bearer token. */
+    private const TRANSIENT_BEARER  = 'wink_bearer_token';
+
+    /** Transient key used to cache the layout list from the Wink API. */
+    private const TRANSIENT_LAYOUTS = 'wink_layouts_data';
+
+    /**
+     * @param string $clientId     Wink affiliate Client ID, read from wp_options.
+     * @param string $clientSecret Wink affiliate Client Secret, read from wp_options.
+     * @param string $environment  Deployment environment: 'production', 'staging', or 'development'.
+     */
+    public function __construct(
+        private string $clientId,
+        private string $clientSecret,
+        private string $environment
+    ) {}
+
+    /**
+     * Returns the affiliate's saved Wink layout list.
+     *
+     * Layouts are cached in a WordPress Transient for WINK_CACHE_TTL seconds (default: 120).
+     * If the transient has expired the method re-authenticates and re-fetches automatically.
+     * Returns an empty array when credentials are missing or either API call fails.
+     *
+     * @return array<int, array{id: string, name: string, layout: string}> Array of layout objects.
+     * @throws WinkAuthException If the OAuth2 token request fails.
+     * @throws WinkDataException If the layout API request fails after successful authentication.
+     */
+    public function getLayouts(): array {
+        if ( empty( $this->clientId ) || empty( $this->clientSecret ) ) {
+            return array();
+        }
+
+        $cached = get_transient( self::TRANSIENT_LAYOUTS );
+        if ( $cached !== false ) {
+            return (array) $cached;
+        }
+
+        $bearerToken = $this->getBearerToken();
+        return $this->fetchLayouts( $bearerToken );
+    }
+
+    /**
+     * Acquires or returns a cached OAuth2 bearer token.
+     *
+     * On cache miss the method performs a client_credentials grant request to the
+     * Wink IAM server. The token is cached using the expires_in value returned by
+     * the server so the transient expires exactly when the token does.
+     *
+     * @return string The bearer token string.
+     * @throws WinkAuthException If the HTTP request fails or the response is missing access_token.
+     */
+    private function getBearerToken(): string {
+        $cached = get_transient( self::TRANSIENT_BEARER );
+        if ( $cached !== false ) {
+            return (string) $cached;
+        }
+
+        $iamUrl  = winkCore::environmentURL( 'json', $this->environment );
+        $postArgs = array(
+            'body'        => array(
+                'client_id'     => $this->clientId,
+                'client_secret' => $this->clientSecret,
+                'grant_type'    => 'client_credentials',
+                'scope'         => 'inventory.read inventory.write',
+            ),
+            'timeout'     => 60,
+            'redirection' => 10,
+            'httpversion' => '1.0',
+            'blocking'    => true,
+            'sslverify'   => true,
+        );
+
+        if ( $this->environment === 'development' ) {
+            error_log( 'Wink: Development environment — SSL verification disabled.' );
+            $postArgs['sslverify'] = false;
+        }
+
+        $response = wp_remote_post( $iamUrl . '/oauth2/token', $postArgs );
+
+        if ( is_wp_error( $response ) ) {
+            throw new WinkAuthException(
+                'OAuth token request failed: ' . $response->get_error_message()
+            );
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = ! empty( $body ) ? json_decode( $body, true ) : null;
+
+        if ( empty( $data['access_token'] ) ) {
+            $httpCode = wp_remote_retrieve_response_code( $response );
+            throw new WinkAuthException(
+                "OAuth response missing access_token (HTTP {$httpCode})."
+            );
+        }
+
+        $ttl = ! empty( $data['expires_in'] ) ? (int) $data['expires_in'] : 3600;
+        set_transient( self::TRANSIENT_BEARER, $data['access_token'], $ttl );
+
+        return $data['access_token'];
+    }
+
+    /**
+     * Fetches the affiliate's saved layout list from the Wink inventory API.
+     *
+     * Caches the result for WINK_CACHE_TTL seconds. Deletes the bearer token transient
+     * on a 401 response so a fresh token is acquired on the next request.
+     *
+     * @param  string $bearerToken A valid OAuth2 bearer token.
+     * @return array<int, array{id: string, name: string, layout: string}>
+     * @throws WinkDataException If the HTTP request fails or the API returns an error.
+     */
+    private function fetchLayouts( string $bearerToken ): array {
+        $apiUrl  = winkCore::environmentURL( 'api', $this->environment );
+        $getArgs = array(
+            'headers'  => array(
+                'Wink-Version'  => '2.0',
+                'Authorization' => 'Bearer ' . $bearerToken,
+            ),
+            'sslverify' => true,
+        );
+
+        if ( $this->environment === 'development' ) {
+            error_log( 'Wink: Development environment — SSL verification disabled.' );
+            $getArgs['sslverify'] = false;
+        }
+
+        $response = wp_remote_get( $apiUrl . '/api/inventory/campaign/list', $getArgs );
+
+        if ( is_wp_error( $response ) ) {
+            throw new WinkDataException(
+                'Layout API request failed: ' . $response->get_error_message()
+            );
+        }
+
+        $httpCode = (int) wp_remote_retrieve_response_code( $response );
+
+        if ( $httpCode === 401 ) {
+            // Bearer token was rejected — delete it so a fresh one is fetched next time.
+            delete_transient( self::TRANSIENT_BEARER );
+            throw new WinkAuthException( "Bearer token rejected by the Wink API (HTTP 401)." );
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = ! empty( $body ) ? json_decode( $body, true ) : null;
+
+        if ( ! is_array( $data ) ) {
+            throw new WinkDataException(
+                "Wink API returned an unreadable response (HTTP {$httpCode})."
+            );
+        }
+
+        if ( $httpCode !== 200 ) {
+            throw new WinkDataException(
+                "Wink API returned error status HTTP {$httpCode}."
+            );
+        }
+
+        set_transient( self::TRANSIENT_LAYOUTS, $data, WINK_CACHE_TTL );
+        return $data;
+    }
+}

--- a/includes/WinkException.php
+++ b/includes/WinkException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Exception hierarchy for the Wink Affiliate WordPress Plugin.
+ *
+ * Typed exceptions allow catch blocks to distinguish between authentication
+ * failures (wrong credentials) and data-fetch failures (API errors, timeouts),
+ * so each can be handled appropriately without catching more than intended.
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Base exception for all Wink plugin errors.
+ *
+ * Catch this type to handle any Wink-specific error regardless of its origin.
+ * Catch the more specific subtypes when you need different handling per error class.
+ */
+class WinkApiException extends \RuntimeException {}
+
+/**
+ * Thrown when the Wink OAuth2 token request fails.
+ *
+ * Common causes: incorrect Client-ID or Client-Secret, network connectivity
+ * issues reaching the Wink IAM server, or an expired client account.
+ */
+class WinkAuthException extends WinkApiException {}
+
+/**
+ * Thrown when a Wink API data request fails after authentication succeeds.
+ *
+ * Common causes: the Wink API server is unreachable, the bearer token expired
+ * mid-request, or the API returned an unexpected error response.
+ */
+class WinkDataException extends WinkApiException {}

--- a/includes/elementHandler.php
+++ b/includes/elementHandler.php
@@ -1,41 +1,179 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-if (!array_key_exists('winkLoaderAlreadyEnqueued',$GLOBALS)) {
-    $GLOBALS['winkLoaderAlreadyEnqueued'] = false;
-}
-
+/**
+ * Abstract base class for all Wink block elements.
+ *
+ * Provides the shared infrastructure used by every Wink element:
+ * - Gutenberg block registration (can be used as-is or overridden)
+ * - Block editor context detection (safe, sanitized $_REQUEST check)
+ * - The <wink-app-loader> footer component (rendered exactly once per page)
+ *
+ * Child classes must assign $this->blockCode and $this->blockName in their
+ * constructor before calling any methods that depend on those values.
+ */
 class winkElements {
-    protected $clientIdKey = 'winkClientId';
-    protected $clientSecretKey = 'winkSecret';
+    /**
+     * Tracks whether the <wink-app-loader> custom element has already been output
+     * to the page footer. Static so it is shared across all element instances.
+     */
+    private static bool $loaderEnqueued = false;
+
+    /** WordPress option key holding the affiliate Client ID credential. */
+    protected string $clientIdKey = WINK_CLIENT_ID_OPTION;
+
+    /** WordPress option key holding the affiliate Client Secret credential. */
+    protected string $clientSecretKey = 'winkSecret';
+
+    /**
+     * Short identifier for this block type (e.g. 'winklookup').
+     * Used as the block slug, script handle suffix, and shortcode name.
+     * Must be set by the child constructor.
+     */
+    protected string $blockCode;
+
+    /**
+     * Human-readable display name shown in the Gutenberg block inserter.
+     * Must be set by the child constructor.
+     */
+    protected string $blockName;
+
+    /**
+     * Gutenberg block attribute definitions passed to register_block_type().
+     * Override in child classes that accept block attributes (e.g. winkContent).
+     *
+     * @var array<string, array{type: string, default: string}>
+     */
+    protected array $attributes = array();
+
+    /**
+     * Absolute URL to the plugin's includes/ directory, with trailing slash.
+     * Computed once in the constructor; never changed after that.
+     */
+    protected string $pluginURL;
+
+    /**
+     * Absolute URL to the plugin's img/ directory, with trailing slash.
+     * Computed once in the constructor; never changed after that.
+     */
+    protected string $imgURL;
+
+    /**
+     * Current deployment environment: 'production', 'staging', or 'development'.
+     * Read from wp_options once in the constructor; never changed after that.
+     */
+    protected string $environmentVal;
+
+    /**
+     * Initialises the shared properties used by all Wink element blocks.
+     * Called via parent::__construct() in each child class constructor.
+     */
     function __construct() {
-        $this->pluginURL = trailingslashit( plugin_dir_url( __FILE__ ) );
-        $this->imgURL = trailingslashit( dirname( plugin_dir_url( __FILE__ ) ) ) . 'img/';
-        $this->environmentVal = get_option('winkEnvironment', 'production');
+        $this->pluginURL      = trailingslashit( plugin_dir_url( __FILE__ ) );
+        $this->imgURL         = trailingslashit( dirname( plugin_dir_url( __FILE__ ) ) ) . 'img/';
+        $this->environmentVal = (string) get_option( 'winkEnvironment', 'production' );
     }
 
-    function coreFunction() {
-        add_action('wp_footer',array($this,'coreComponent'));
+    /**
+     * Registers the wp_footer action to output the <wink-app-loader> web component.
+     *
+     * Call this from blockHandler() so the Wink app-loader element is injected into
+     * the page footer whenever a Wink block is present on the page.
+     *
+     * @return void
+     */
+    function coreFunction(): void {
+        add_action( 'wp_footer', array( $this, 'coreComponent' ) );
     }
-    function coreComponent() {
-        if ($GLOBALS['winkLoaderAlreadyEnqueued'] == false) {
-            $html = '';
-            $clientId = get_option($this->clientIdKey, false);
-            
-            echo'<wink-app-loader client-id="'.esc_html($clientId).'"></wink-app-loader>';
-            $GLOBALS['winkLoaderAlreadyEnqueued'] = true;
+
+    /**
+     * Outputs the <wink-app-loader> custom element to the page footer.
+     *
+     * The loader must appear exactly once per page regardless of how many Wink
+     * blocks are present. After the first call outputs the element, all subsequent
+     * calls from other blocks on the same page are silently ignored.
+     *
+     * @return bool True once the loader has been output; false if already output (no-op).
+     */
+    function coreComponent(): bool {
+        if ( self::$loaderEnqueued === false ) {
+            $clientId = (string) get_option( $this->clientIdKey, '' );
+            echo '<wink-app-loader client-id="' . esc_attr( $clientId ) . '"></wink-app-loader>';
+            self::$loaderEnqueued = true;
         }
-        return $GLOBALS['winkLoaderAlreadyEnqueued'];
+        return self::$loaderEnqueued;
+    }
+
+    /**
+     * Determines whether the current request originates from the Gutenberg block editor.
+     *
+     * Gutenberg's REST API preview requests include context=edit or action=edit in the
+     * request parameters. Values are sanitized with sanitize_key() before comparison so
+     * that any characters outside [a-z0-9_-] are stripped, even though we only compare
+     * and never output the value.
+     *
+     * @return bool True when rendering inside the block editor; false on the front end.
+     */
+    protected function isEditorContext(): bool {
+        $context = isset( $_REQUEST['context'] ) ? sanitize_key( $_REQUEST['context'] ) : '';
+        $action  = isset( $_REQUEST['action'] )  ? sanitize_key( $_REQUEST['action'] )  : '';
+        return is_admin() || $context === 'edit' || $action === 'edit';
+    }
+
+    /**
+     * Registers this element as a Gutenberg block type.
+     *
+     * Hooked to the WordPress 'init' action. Does nothing when register_block_type()
+     * is not available (i.e. Gutenberg is not active).
+     *
+     * Child classes may override this method to supply additional wp_localize_script()
+     * data (see winkContent for an example).
+     *
+     * @return void
+     */
+    function gutenbergBlockRegistration(): void {
+        if ( ! function_exists( 'register_block_type' ) ) {
+            return;
+        }
+
+        $handle = 'winkBlockRenderer_' . $this->blockCode;
+
+        wp_register_script(
+            $handle,
+            $this->pluginURL . 'elements/js/' . $this->blockCode . '.js',
+            array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-editor' ),
+            false
+        );
+
+        wp_localize_script( $handle, 'winkData', array(
+            'blockCat' => 'wink2travel-blocks',
+            'imgURL'   => $this->imgURL,
+            'mode'     => $this->environmentVal,
+        ) );
+
+        register_block_type( 'wink-blocks/' . $this->blockCode, array(
+            'editor_script'   => $handle,
+            'render_callback' => array( $this, 'blockHandler' ),
+            'attributes'      => $this->attributes,
+            'category'        => 'wink2travel-blocks',
+        ) );
     }
 }
 
-require_once('elements/winklookup.php'); // Lookup element
-require_once('elements/winkitinerary.php'); // Itinerary button element
-require_once('elements/winkitineraryform.php'); // Itinerary form element
-require_once('elements/winksearch.php'); // Search button element
-require_once('elements/winkaccount.php'); // Account button element
-require_once('elements/winkcontent.php'); // Content element
+// Exception hierarchy and API client must load first so any element file can reference them.
+require_once dirname( __FILE__ ) . '/WinkException.php';
+require_once dirname( __FILE__ ) . '/WinkApiClient.php';
+require_once 'elements/winklookup.php';
+require_once 'elements/winkitinerary.php';
+require_once 'elements/winkitineraryform.php';
+require_once 'elements/winksearch.php';
+require_once 'elements/winkaccount.php';
+require_once 'elements/winkcontent.php';
 
-require_once('elements/wpbakery/vcElements.php'); // WPBakery Page Builder
-require_once('elements/elementor/elementorWidgets.php'); // Elementor
-require_once('elements/avada/fusionElements.php'); // Avada / Fusion Builder
+// Page-builder integrations call add_action()/add_filter() at the module level,
+// so skip them entirely when running under PHPUnit.
+if ( ! defined( 'WINK_TESTING' ) ) {
+    require_once 'elements/wpbakery/vcElements.php';
+    require_once 'elements/elementor/elementorWidgets.php';
+    require_once 'elements/avada/fusionElements.php';
+}

--- a/includes/elements/winkaccount.php
+++ b/includes/elements/winkaccount.php
@@ -1,80 +1,73 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/**
+ * Wink Account block element.
+ *
+ * Renders a <wink-account-button> custom element that provides sign-in / account
+ * management functionality for the Wink affiliate travel platform.
+ * Supports Gutenberg blocks, shortcodes, WPBakery, Elementor, and Avada.
+ */
 class winkAccount extends winkElements {
+    /**
+     * Registers the Gutenberg block, shortcode, and Customizer data filter for this element.
+     */
     function __construct() {
         parent::__construct();
         $this->blockCode = 'winkaccount';
-        $this->blockName = esc_html__( "Wink Account", "wink2travel" );
-        add_action('init', array( $this,'gutenbergBlockRegistration' ) ); // Adding Gutenberg Block
-        add_shortcode( $this->blockCode, array( $this,'blockHandler') );
-        add_filter('winkShortcodes',array( $this, 'shortcodeData') );
+        $this->blockName = esc_html__( 'Wink Account', 'wink2travel' );
+        add_action( 'init', array( $this, 'gutenbergBlockRegistration' ) );
+        add_shortcode( $this->blockCode, array( $this, 'blockHandler' ) );
+        add_filter( 'winkShortcodes', array( $this, 'shortcodeData' ) );
     }
-    function shortcodeData($shortcodes) {
+
+    /**
+     * Provides shortcode metadata for the Customizer settings panel and WPBakery.
+     *
+     * @param  array $shortcodes Existing shortcode definitions.
+     * @return array Shortcode definitions with this element appended.
+     */
+    function shortcodeData( array $shortcodes ): array {
         $shortcodes[] = array(
-            'code' => $this->blockCode,
-            'name' => $this->blockName,
-            'params' => array() 
+            'code'   => $this->blockCode,
+            'name'   => $this->blockName,
+            'params' => array(),
         );
         return $shortcodes;
     }
-    function blockHandler($atts) {
+
+    /**
+     * Outputs the <wink-app-loader> footer component and renders the block HTML.
+     * Used as the render_callback for register_block_type() and as the shortcode handler.
+     *
+     * @param  array|string $atts Block attributes or shortcode attributes (unused for this element).
+     * @return string The rendered HTML for this element.
+     */
+    function blockHandler( $atts ): string {
         $this->coreFunction();
         return $this->winkElement();
     }
-    function winkElement() {
+
+    /**
+     * Returns the HTML for the <wink-account-button> custom element.
+     *
+     * In the Gutenberg editor context the HTML is returned as an escaped string so the
+     * block preview renders the tag text rather than trying to initialise the web component.
+     *
+     * @return string The element HTML.
+     */
+    function winkElement(): string {
         ob_start();
         ?><wink-account-button></wink-account-button><?php
-        $content = ob_get_contents();
-        ob_end_clean();
-        $isAdmin = false;
-        if (!empty($_REQUEST['context']) && $_REQUEST['context'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (!empty($_REQUEST['action']) && $_REQUEST['action'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (is_admin( ) || $isAdmin) {
-            return htmlspecialchars($content);
+        $content = (string) ob_get_clean();
+
+        if ( $this->isEditorContext() ) {
+            return htmlspecialchars( $content );
         }
         return $content;
     }
-
-    function gutenbergBlockRegistration() {
-        // Skip block registration if Gutenberg is not enabled/merged.
-        if (!function_exists('register_block_type')) {
-            return;
-        }
-        
-        $dir = dirname(__FILE__);
-
-        $gutenbergJS = $this->blockCode.'.js';
-        wp_register_script('winkBlockRenderer_'.$this->blockCode, $this->pluginURL . 'elements/js/'.$gutenbergJS,
-            array(
-                'wp-blocks',
-                'wp-i18n',
-                'wp-element',
-                'wp-components',
-                'wp-editor'
-            ),
-            false
-        );
-
-        $jsData = array(
-            'blockCat'  => "wink2travel".'-blocks',
-            'imgURL'    => $this->imgURL,
-            'mode'      => $this->environmentVal
-        );
-
-        wp_localize_script( 'winkBlockRenderer_'.$this->blockCode, 'winkData', $jsData );
-        
-        register_block_type('wink-blocks/'.$this->blockCode, array(
-            'editor_script' => 'winkBlockRenderer_'.$this->blockCode,
-            'render_callback' => array($this,'blockHandler'),
-            'attributes' => [],
-            'category' => "wink2travel".'-blocks'
-        ));
-    }
 }
 
-$winkAccount = new winkAccount();
+if ( ! defined( 'WINK_TESTING' ) ) {
+    $winkAccount = new winkAccount();
+}

--- a/includes/elements/winkcontent.php
+++ b/includes/elements/winkcontent.php
@@ -1,295 +1,228 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) exit;
 
+/**
+ * Wink Content block element.
+ *
+ * Renders a <wink-content-loader> custom element that displays a saved Wink
+ * affiliate inventory layout (e.g. a hotel grid, tour list, or activity carousel).
+ *
+ * This class handles rendering only. All API communication (OAuth token acquisition
+ * and layout data fetching) is delegated to WinkApiClient.
+ *
+ * Supports Gutenberg blocks, shortcodes, WPBakery, Elementor, and Avada page builders.
+ */
 class winkContent extends winkElements {
+    /**
+     * API client instance responsible for fetching layout data from the Wink REST API.
+     * Instantiated in the constructor and reused across all method calls.
+     */
+    protected WinkApiClient $apiClient;
+
+    /**
+     * Registers the Gutenberg block, shortcode, and Customizer data filter.
+     * Instantiates the WinkApiClient with sanitized credentials from wp_options.
+     */
     function __construct() {
         parent::__construct();
         $this->blockCode = 'winkcontent';
-        $this->blockName = esc_html__( "wink Content", "wink2travel" );
-        $this->attributes = [
-            'layout' => [
-                'default' => '',
-                'type' => 'string'
-            ],
-            'layoutId' => [
-                'default' => '',
-                'type' => 'string'
-            ],
-            'background' => [
-                'default' => '',
-                'type' => 'string'
-            ],
-        ];
-        add_action('init', array($this, 'gutenbergBlockRegistration')); // Adding Gutenberg Block
-        add_shortcode($this->blockCode, array($this, 'blockHandler'));
-        add_filter('winkShortcodes',array( $this, 'shortcodeData') );
-    }
-    function shortcodeData($shortcodes) {
-        $winkContentData = $this->getwinkBearerToken();
-        $values = array(
-            esc_html__( 'Select...',  "wink2travel"  ) => ''
-
+        $this->blockName = esc_html__( 'wink Content', 'wink2travel' );
+        $this->attributes = array(
+            'layout'     => array( 'default' => '', 'type' => 'string' ),
+            'layoutId'   => array( 'default' => '', 'type' => 'string' ),
+            'background' => array( 'default' => '', 'type' => 'string' ),
         );
-        foreach($winkContentData as $key => $localValue) {
-            $values[$localValue['name']] = $localValue['id'];
+
+        // Sanitize credentials when reading from the database so any characters
+        // that could interfere with HTTP headers (e.g. newlines) are removed.
+        $clientId     = sanitize_text_field( (string) get_option( $this->clientIdKey, '' ) );
+        $clientSecret = sanitize_text_field( (string) get_option( $this->clientSecretKey, '' ) );
+
+        $this->apiClient = new WinkApiClient( $clientId, $clientSecret, $this->environmentVal );
+
+        add_action( 'init', array( $this, 'gutenbergBlockRegistration' ) );
+        add_shortcode( $this->blockCode, array( $this, 'blockHandler' ) );
+        add_filter( 'winkShortcodes', array( $this, 'shortcodeData' ) );
+    }
+
+    /**
+     * Provides shortcode metadata including a dropdown of the affiliate's saved layouts.
+     *
+     * The layout list is fetched via WinkApiClient (cached for WINK_CACHE_TTL seconds).
+     * On API failure an empty dropdown is returned so the Customizer remains functional.
+     *
+     * @param  array $shortcodes Existing shortcode definitions.
+     * @return array Shortcode definitions with this element appended.
+     */
+    function shortcodeData( array $shortcodes ): array {
+        $values = array( esc_html__( 'Select...', 'wink2travel' ) => '' );
+
+        try {
+            $layouts = $this->apiClient->getLayouts();
+            foreach ( $layouts as $layout ) {
+                $values[ $layout['name'] ] = $layout['id'];
+            }
+        } catch ( WinkApiException $e ) {
+            error_log( 'Wink: Could not load layouts for Customizer — ' . $e->getMessage() );
         }
-        $shortcodes[$this->blockCode] = array(
-            'code' => $this->blockCode,
-            'name' => $this->blockName,
+
+        $shortcodes[ $this->blockCode ] = array(
+            'code'   => $this->blockCode,
+            'name'   => $this->blockName,
             'params' => array(
                 array(
-                    "type" => "dropdown",
-                    "holder" => "div",
-                    "class" => "",
-                    "heading" => __( "Inventory", "wink2travel" ),
-                    "param_name" => "layoutid",
-                    'value' => $values,
-                    "description" => __('Select any of your saved layouts. We strongly recommend to use this block only in full-width content areas and not in columns.', "wink2travel" )
+                    'type'        => 'dropdown',
+                    'holder'      => 'div',
+                    'class'       => '',
+                    'heading'     => __( 'Inventory', 'wink2travel' ),
+                    'param_name'  => 'layoutid',
+                    'value'       => $values,
+                    'description' => __( 'Select any of your saved layouts. We strongly recommend to use this block only in full-width content areas and not in columns.', 'wink2travel' ),
                 ),
-            )
+            ),
         );
         return $shortcodes;
     }
-    
-    function blockHandler($atts) {
+
+    /**
+     * Outputs the <wink-app-loader> footer component and renders the block HTML.
+     * Used as the render_callback for register_block_type() and as the shortcode handler.
+     *
+     * @param  array|string $atts Block attributes or shortcode attributes.
+     * @return string The rendered HTML for this element.
+     */
+    function blockHandler( $atts ): string {
         $this->coreFunction();
-        return $this->winkElement($atts);
+        return $this->winkElement( (array) $atts );
     }
 
-    function winkElement($atts) {
+    /**
+     * Returns the HTML for the <wink-content-loader> custom element.
+     *
+     * Resolves the layout type from the supplied attributes, optionally looking it up via
+     * the Wink API when only a layout ID is provided. Falls back to 'HOTEL' when the layout
+     * type cannot be determined.
+     *
+     * On API failure in the Gutenberg editor context a user-readable error message is returned
+     * so the site owner can identify the problem. On the front end, an empty string is returned
+     * (fail silently — visitors should not see error messages from back-end API calls).
+     *
+     * @param  array $atts Block or shortcode attributes. Keys: layout, layoutId, layoutid, background.
+     * @return string The element HTML, an editor error message, or empty string on front-end failure.
+     */
+    function winkElement( array $atts ): string {
+        // Values are stored as raw strings here. Escaping is applied at the output
+        // step (inside the array_map closure below), following WordPress's "escape late"
+        // security principle: escaping at the point of output prevents any future code
+        // path from writing to $config without going through the escape gate.
         $config = array();
-        if (!empty($atts['layout'])) {
-            $config['layout'] = esc_html($atts['layout']);
+
+        if ( ! empty( $atts['layout'] ) ) {
+            $config['layout'] = (string) $atts['layout'];
         }
-        if (!empty($atts['layoutid'])) {
-            $atts['layoutId'] = $atts['layoutid']; // WPB Fallback
+
+        // WPBakery passes 'layoutid' (lowercase); normalise to 'layoutId'.
+        if ( ! empty( $atts['layoutid'] ) ) {
+            $atts['layoutId'] = $atts['layoutid'];
         }
-        
-        if (!empty($atts['layoutId'])) {
-            $config['id'] = esc_html($atts['layoutId']);
-            if (empty($atts['layout'])) {
-                $winkContentData = $this->getwinkBearerToken();
-                $layoutName = '';
-                foreach($winkContentData as $key => $localValue) {
-                    if ($localValue['id'] == $config['id']) {
-                        $layoutName = $localValue['layout'];
-                    }
-                }
-                if (!empty($layoutName)) {
-                    $config['layout'] = esc_html($layoutName);
-                } else {
-                    $config['layout'] = "HOTEL";
-                }
+
+        if ( ! empty( $atts['layoutId'] ) ) {
+            $config['id'] = (string) $atts['layoutId'];
+
+            if ( empty( $config['layout'] ) ) {
+                $config['layout'] = $this->resolveLayoutType( $config['id'] );
             }
         }
-        if (empty($config['layout']) && !empty($config['id'])) {
-            $winkContentData = $this->getwinkBearerToken();
-            $layoutName = '';
-            foreach($winkContentData as $key => $localValue) {
-                if ($localValue['id'] == $config['id']) {
-                    $layoutName = $localValue['layout'];
+
+        // Escape values at output time so all paths through $config are covered.
+        $attrs = implode( ' ', array_map(
+            function ( string $key ) use ( $config ): string {
+                $value = $config[ $key ];
+                if ( is_bool( $value ) ) {
+                    return $value ? esc_attr( $key ) : '';
                 }
-            }
-            if (!empty($layoutName)) {
-                $config['layout'] = esc_html($layoutName);
-            } else {
-                $config['layout'] = "HOTEL";
-            }
-        }
-		$attrs = join(' ', array_map(function($key) use ($config){
-			if(is_bool($config[$key])){
-				return $config[$key]?$key:'';
-			}
-			return $key.'="'.$config[$key].'"';
-		}, array_keys($config)));
+                return esc_attr( $key ) . '="' . esc_attr( $value ) . '"';
+            },
+            array_keys( $config )
+        ) );
+
         ob_start();
         ?>
         <wink-content-loader <?php echo $attrs; ?>></wink-content-loader>
         <?php
-        $content = ob_get_contents();
-        ob_end_clean();
-        $isAdmin = false;
-        if (!empty($_REQUEST['context']) && $_REQUEST['context'] == 'edit') {
-            $isAdmin = true;
+        $content = (string) ob_get_clean();
+
+        if ( $this->isEditorContext() ) {
+            return htmlspecialchars( $content );
         }
-        if (!empty($_REQUEST['action']) && $_REQUEST['action'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (is_admin() || $isAdmin) {
-            return htmlspecialchars($content);
-        }
-        //error_log(str_replace("&quot;",'"',$content));
-        return str_replace('&quot;','"',$content);
+        return $content;
     }
 
-    function getwinkBearerToken()
-    {
-        $env = winkCore::environmentURL('json', $this->environmentVal);
-        //error_log($env);
-        $clientId = get_option($this->clientIdKey, false);
-        $clientSecret = get_option($this->clientSecretKey, false);
-
-        // get current access token time to see if we can use the last one
-        $bearerTime = get_option('winkcontentTime', 0);
-        $currentTime = current_time('timestamp');
-        $bearerToken = '';
-        $winkLayouts = get_option('winkData', array());
-
-        if ($bearerTime < $currentTime || empty($winkLayouts)) {
-            
-            $postBody = array(
-                'client_id'    => $clientId,
-                'client_secret'   => $clientSecret,
-                'grant_type' => 'client_credentials',
-                'scope' => 'inventory.read inventory.write',
-            );
-            $postArgs = array(
-                'body'        => $postBody,
-                'timeout'     => 60,
-                'redirection' => 10,
-                'httpversion' => '1.0',
-                'blocking'    => true,
-                'sslverify' => true,
-            );
-            if ($this->environmentVal == 'development') {
-                error_log('Wink - Development environment. Ignoring self-signed certificates');
-                $postArgs['sslverify'] = false; 
-            }
-            $url = $env . '/oauth2/token';
-            $response = wp_remote_post($url,$postArgs);
-            if ( is_wp_error( $response ) ) {
-                // print out any error
-                error_log('Wink - Empty response when trying to retrieve token. Details below:');
-                error_log($response->get_error_message());
-            } else {
-                if (!empty($response['body'])) {
-                    $data = json_decode($response['body'], true);
-
-                    if (!empty($data)) {
-    //                    error_log('Wink - token $data' . $data);
-                        if (!empty($data['access_token']) && !empty($data['expires_in'])) {
-                            update_option('winkcontentBearer', $data['access_token']);
-                            update_option('winkcontentTime', $data['expires_in'] + current_time('timestamp'));
-                            $bearerToken = $data['access_token'];
-                        }
-                    } else {
-                        error_log('Wink - Empty response body when trying to retrieve token.');
-                    }
-                } else {
-                    error_log('Wink - Unable to get response body content while retrieving token. Response array below:');
-                    error_log(print_r($response,true));
-                }
-            }
-        } else {
-            // retrieve existing bearer token
-            $bearerToken = get_option('winkcontentBearer', '');
+    /**
+     * Looks up the layout type string (e.g. 'HOTEL') for a given layout ID.
+     *
+     * Fetches the full layout list via WinkApiClient (cached) and searches for a match.
+     * Returns 'HOTEL' as a safe default when the layout is not found or the API fails.
+     *
+     * On authentication failure an admin notice transient is set so the site owner
+     * sees an error banner in the WordPress dashboard.
+     *
+     * @param  string $layoutId The Wink layout ID to look up.
+     * @return string The layout type string, or 'HOTEL' if not found.
+     */
+    protected function resolveLayoutType( string $layoutId ): string {
+        try {
+            $layouts = $this->apiClient->getLayouts();
+        } catch ( WinkAuthException $e ) {
+            error_log( 'Wink: Authentication failed while resolving layout type — ' . $e->getMessage() );
+            set_transient( 'wink_auth_error', $e->getMessage(), HOUR_IN_SECONDS );
+            return 'HOTEL';
+        } catch ( WinkDataException $e ) {
+            error_log( 'Wink: API error while resolving layout type — ' . $e->getMessage() );
+            return 'HOTEL';
         }
 
-        if (!empty($bearerToken)) {
-            return $this->getwinkLayouts($bearerToken);
-        } else {
-            error_log('Wink - Bearer token empty');
+        foreach ( $layouts as $layout ) {
+            if ( isset( $layout['id'] ) && $layout['id'] === $layoutId ) {
+                // Return the raw string; escaping is applied at the output step in winkElement().
+                return ! empty( $layout['layout'] ) ? (string) $layout['layout'] : 'HOTEL';
+            }
         }
 
-        return array();
+        return 'HOTEL';
     }
 
-    function getwinkLayouts($bearerToken) {
-        $env = winkCore::environmentURL('api', $this->environmentVal);
-        $currentTime = current_time('timestamp');
-        $dataTime = get_option('winkdataTime', 0);
+    /**
+     * Registers this element as a Gutenberg block type and provides the editor with
+     * the affiliate's saved layout list for the layout picker dropdown.
+     *
+     * Extends the base gutenbergBlockRegistration() by adding a second wp_localize_script()
+     * call with the layout data. On API failure an empty array is passed so the editor
+     * remains functional (the dropdown will be empty rather than throwing an error).
+     *
+     * @return void
+     */
+    function gutenbergBlockRegistration(): void {
+        parent::gutenbergBlockRegistration();
 
-        $winkLayouts = get_option('winkData', array());
-        if ($dataTime < $currentTime || empty($winkLayouts)) {
-            $url = $env . '/api/inventory/campaign/list';
-            $options = array('http' => array(
-                'method'  => 'GET',
-                'Wink-Version'  => '2.0',
-                'header' => 'Authorization: Bearer '.$bearerToken
-            ));
-            $context  = stream_context_create($options);
-            $getArgs = array(
-                'headers' => array(
-                    'Wink-Version'  => '2.0',
-                    'Authorization' => 'Bearer '.$bearerToken
-                )
-            );
-            if ($this->environmentVal == 'development') {
-                error_log('Wink - Development environment. Ignoring self-signed certificates');
-                $getArgs['sslverify'] = false; 
-            }
-            $response = wp_remote_get($url,$getArgs);
-            if ( is_wp_error( $response ) ) {
-                // print out any error
-                error_log('Wink - Empty response when trying to retrieve layouts. Details below:');
-                error_log($response->get_error_message());
-            } else {
-                if (!empty($response['body'])) {
-                    $data = json_decode($response['body'], true);
-                    if (!empty($data)) {
-                        if (!empty($data['status']) && $data['error'] == 404) {
-                            delete_option( 'winkData' );
-                            delete_option( 'winkdataTime' );
-                            error_log('Wink - Unable to retrieve layout data.');
-                        } else {
-                            // error_log('Wink - layout $data' . $data);
-                            update_option('winkData', $data);
-                            update_option('winkdataTime', 60 * 2 + current_time('timestamp')); // 2 minutes
-                            return $data;
-                        }
-                    } else {
-                        error_log('Wink - Unable to get response body content while retrieving layouts. Response array below:');
-                        error_log(print_r($response,true));
-                    }
-            }
-        }
-        } else {
-            return $winkLayouts;
-        }
-        return array();
-    }
-
-    function gutenbergBlockRegistration()
-    {
-        // Skip block registration if Gutenberg is not enabled/merged.
-        if (!function_exists('register_block_type')) {
-            return;
+        $layouts = array();
+        try {
+            $layouts = $this->apiClient->getLayouts();
+        } catch ( WinkAuthException $e ) {
+            error_log( 'Wink: Authentication failed during block registration — ' . $e->getMessage() );
+            set_transient( 'wink_auth_error', $e->getMessage(), HOUR_IN_SECONDS );
+        } catch ( WinkDataException $e ) {
+            error_log( 'Wink: Could not load layouts for block editor — ' . $e->getMessage() );
         }
 
-        $dir = dirname(__FILE__);
-
-        $gutenbergJS = $this->blockCode . '.js';
-        wp_register_script('winkBlockRenderer_' . $this->blockCode, $this->pluginURL . 'elements/js/' . $gutenbergJS,
-            array(
-                'wp-blocks',
-                'wp-i18n',
-                'wp-element',
-                'wp-components',
-                'wp-editor',
-                'jquery'
-            ),
-            false
+        wp_localize_script(
+            'winkBlockRenderer_' . $this->blockCode,
+            'winkContentData',
+            $layouts
         );
-
-        $jsData = array(
-            'blockCat' => "wink2travel" . '-blocks',
-            'imgURL' => $this->imgURL,
-            'mode' => $this->environmentVal
-        );
-
-        wp_localize_script('winkBlockRenderer_' . $this->blockCode, 'winkData', $jsData);
-
-        $clientId = get_option($this->clientIdKey, false);
-        $winkContentData = $this->getwinkBearerToken();
-        wp_localize_script('winkBlockRenderer_' . $this->blockCode, 'winkContentData', $winkContentData);
-
-        register_block_type('wink-blocks/' . $this->blockCode, array(
-            'editor_script' => 'winkBlockRenderer_' . $this->blockCode,
-            'render_callback' => array($this, 'blockHandler'),
-            'attributes' => $this->attributes,
-            'category' => "wink2travel" . '-blocks'
-        ));
     }
 }
 
-$winkContent = new winkContent();
+if ( ! defined( 'WINK_TESTING' ) ) {
+    $winkContent = new winkContent();
+}

--- a/includes/elements/winkitinerary.php
+++ b/includes/elements/winkitinerary.php
@@ -1,85 +1,73 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/**
+ * Wink Itinerary block element.
+ *
+ * Renders a <wink-itinerary-button> custom element that opens a user's saved
+ * travel itinerary from the Wink affiliate platform.
+ * Supports Gutenberg blocks, shortcodes, WPBakery, Elementor, and Avada.
+ */
 class winkItinerary extends winkElements {
+    /**
+     * Registers the Gutenberg block, shortcode, and Customizer data filter for this element.
+     */
     function __construct() {
         parent::__construct();
         $this->blockCode = 'winkitinerary';
-        $this->blockName = esc_html__( "wink Itinerary Button", "wink2travel" );
-        add_action('init', array( $this,'gutenbergBlockRegistration' ) ); // Adding Gutenberg Block
-        add_shortcode( $this->blockCode, array( $this,'blockHandler') );
-        add_filter('winkShortcodes',array( $this, 'shortcodeData') );
+        $this->blockName = esc_html__( 'wink Itinerary Button', 'wink2travel' );
+        add_action( 'init', array( $this, 'gutenbergBlockRegistration' ) );
+        add_shortcode( $this->blockCode, array( $this, 'blockHandler' ) );
+        add_filter( 'winkShortcodes', array( $this, 'shortcodeData' ) );
     }
-    function shortcodeData($shortcodes) {
+
+    /**
+     * Provides shortcode metadata for the Customizer settings panel and WPBakery.
+     *
+     * @param  array $shortcodes Existing shortcode definitions.
+     * @return array Shortcode definitions with this element appended.
+     */
+    function shortcodeData( array $shortcodes ): array {
         $shortcodes[] = array(
-            'code' => $this->blockCode,
-            'name' => $this->blockName,
-            'params' => array() 
+            'code'   => $this->blockCode,
+            'name'   => $this->blockName,
+            'params' => array(),
         );
         return $shortcodes;
     }
-    function blockHandler($atts) {
+
+    /**
+     * Outputs the <wink-app-loader> footer component and renders the block HTML.
+     * Used as the render_callback for register_block_type() and as the shortcode handler.
+     *
+     * @param  array|string $atts Block attributes or shortcode attributes (unused for this element).
+     * @return string The rendered HTML for this element.
+     */
+    function blockHandler( $atts ): string {
         $this->coreFunction();
         return $this->winkElement();
     }
-    function winkElement() {
+
+    /**
+     * Returns the HTML for the <wink-itinerary-button> custom element.
+     *
+     * In the Gutenberg editor context the HTML is returned as an escaped string so the
+     * block preview renders the tag text rather than trying to initialise the web component.
+     *
+     * @return string The element HTML.
+     */
+    function winkElement(): string {
         ob_start();
         ?><wink-itinerary-button></wink-itinerary-button><?php
-        $content = ob_get_contents();
-        ob_end_clean();
-        $isAdmin = false;
-        if (!empty($_REQUEST['context']) && $_REQUEST['context'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (!empty($_REQUEST['action']) && $_REQUEST['action'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (is_admin( ) || $isAdmin) { // in editor we should show the raw HTML to make it easier to click on
-            return htmlspecialchars($content);
+        $content = (string) ob_get_clean();
+
+        if ( $this->isEditorContext() ) {
+            return htmlspecialchars( $content );
         }
         return $content;
     }
-
-    function gutenbergBlockRegistration() {
-        // Skip block registration if Gutenberg is not enabled/merged.
-        if (!function_exists('register_block_type')) {
-            return;
-        }
-        
-        $dir = dirname(__FILE__);
-
-        $gutenbergJS = $this->blockCode.'.js';
-        wp_register_script('winkBlockRenderer_'.$this->blockCode, $this->pluginURL . 'elements/js/'.$gutenbergJS,
-            array(
-                'wp-blocks',
-                'wp-i18n',
-                'wp-element',
-                'wp-components',
-                'wp-editor'
-            ),
-            false
-        );
-
-        $jsData = array(
-            'blockCat'  => "wink2travel".'-blocks',
-            'imgURL'    => $this->imgURL,
-            'mode'      => $this->environmentVal
-        );
-
-        wp_localize_script( 'winkBlockRenderer_'.$this->blockCode, 'winkData', $jsData );
-        
-        register_block_type('wink-blocks/'.$this->blockCode, array(
-            'editor_script' => 'winkBlockRenderer_'.$this->blockCode,
-            'render_callback' => array($this,'blockHandler'),
-            'attributes' => [
-                // 'configurationId' => [
-                //     'default' => '',
-                //     'type' => 'string'
-                // ]
-            ],
-            'category' => "wink2travel".'-blocks'
-        ));
-    }
 }
 
-$winkItinerary = new winkItinerary();
+if ( ! defined( 'WINK_TESTING' ) ) {
+    $winkItinerary = new winkItinerary();
+}

--- a/includes/elements/winkitineraryform.php
+++ b/includes/elements/winkitineraryform.php
@@ -1,85 +1,73 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/**
+ * Wink Itinerary Form block element.
+ *
+ * Renders a <wink-itinerary-form> custom element that displays a form for
+ * creating or managing a travel itinerary on the Wink affiliate platform.
+ * Supports Gutenberg blocks, shortcodes, WPBakery, Elementor, and Avada.
+ */
 class winkItineraryForm extends winkElements {
+    /**
+     * Registers the Gutenberg block, shortcode, and Customizer data filter for this element.
+     */
     function __construct() {
         parent::__construct();
         $this->blockCode = 'winkitineraryform';
-        $this->blockName = esc_html__( "wink Itinerary Form", "wink2travel" );
-        add_action('init', array( $this,'gutenbergBlockRegistration' ) ); // Adding Gutenberg Block
-        add_shortcode( $this->blockCode, array( $this,'blockHandler') );
-        add_filter('winkShortcodes',array( $this, 'shortcodeData') );
+        $this->blockName = esc_html__( 'wink Itinerary Form', 'wink2travel' );
+        add_action( 'init', array( $this, 'gutenbergBlockRegistration' ) );
+        add_shortcode( $this->blockCode, array( $this, 'blockHandler' ) );
+        add_filter( 'winkShortcodes', array( $this, 'shortcodeData' ) );
     }
-    function shortcodeData($shortcodes) {
+
+    /**
+     * Provides shortcode metadata for the Customizer settings panel and WPBakery.
+     *
+     * @param  array $shortcodes Existing shortcode definitions.
+     * @return array Shortcode definitions with this element appended.
+     */
+    function shortcodeData( array $shortcodes ): array {
         $shortcodes[] = array(
-            'code' => $this->blockCode,
-            'name' => $this->blockName,
-            'params' => array() 
+            'code'   => $this->blockCode,
+            'name'   => $this->blockName,
+            'params' => array(),
         );
         return $shortcodes;
     }
-    function blockHandler($atts) {
+
+    /**
+     * Outputs the <wink-app-loader> footer component and renders the block HTML.
+     * Used as the render_callback for register_block_type() and as the shortcode handler.
+     *
+     * @param  array|string $atts Block attributes or shortcode attributes (unused for this element).
+     * @return string The rendered HTML for this element.
+     */
+    function blockHandler( $atts ): string {
         $this->coreFunction();
         return $this->winkElement();
     }
-    function winkElement() {
+
+    /**
+     * Returns the HTML for the <wink-itinerary-form> custom element.
+     *
+     * In the Gutenberg editor context the HTML is returned as an escaped string so the
+     * block preview renders the tag text rather than trying to initialise the web component.
+     *
+     * @return string The element HTML.
+     */
+    function winkElement(): string {
         ob_start();
         ?><wink-itinerary-form></wink-itinerary-form><?php
-        $content = ob_get_contents();
-        ob_end_clean();
-        $isAdmin = false;
-        if (!empty($_REQUEST['context']) && $_REQUEST['context'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (!empty($_REQUEST['action']) && $_REQUEST['action'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (is_admin( ) || $isAdmin) { // in editor we should show the raw HTML to make it easier to click on
-            return htmlspecialchars($content);
+        $content = (string) ob_get_clean();
+
+        if ( $this->isEditorContext() ) {
+            return htmlspecialchars( $content );
         }
         return $content;
     }
-
-    function gutenbergBlockRegistration() {
-        // Skip block registration if Gutenberg is not enabled/merged.
-        if (!function_exists('register_block_type')) {
-            return;
-        }
-        
-        $dir = dirname(__FILE__);
-
-        $gutenbergJS = $this->blockCode.'.js';
-        wp_register_script('winkBlockRenderer_'.$this->blockCode, $this->pluginURL . 'elements/js/'.$gutenbergJS,
-            array(
-                'wp-blocks',
-                'wp-i18n',
-                'wp-element',
-                'wp-components',
-                'wp-editor'
-            ),
-            false
-        );
-
-        $jsData = array(
-            'blockCat'  => "wink2travel".'-blocks',
-            'imgURL'    => $this->imgURL,
-            'mode'      => $this->environmentVal
-        );
-
-        wp_localize_script( 'winkBlockRenderer_'.$this->blockCode, 'winkData', $jsData );
-        
-        register_block_type('wink-blocks/'.$this->blockCode, array(
-            'editor_script' => 'winkBlockRenderer_'.$this->blockCode,
-            'render_callback' => array($this,'blockHandler'),
-            'attributes' => [
-                // 'configurationId' => [
-                //     'default' => '',
-                //     'type' => 'string'
-                // ]
-            ],
-            'category' => "wink2travel".'-blocks'
-        ));
-    }
 }
 
-$winkItineraryForm = new winkItineraryForm();
+if ( ! defined( 'WINK_TESTING' ) ) {
+    $winkItineraryForm = new winkItineraryForm();
+}

--- a/includes/elements/winklookup.php
+++ b/includes/elements/winklookup.php
@@ -1,85 +1,73 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/**
+ * Wink Lookup block element.
+ *
+ * Renders a <wink-lookup> custom element that provides a full-page travel search
+ * and booking lookup interface. Supports Gutenberg blocks, shortcodes, WPBakery,
+ * Elementor, and Avada page builders.
+ */
 class winkLookup extends winkElements {
+    /**
+     * Registers the Gutenberg block, shortcode, and Customizer data filter for this element.
+     */
     function __construct() {
         parent::__construct();
         $this->blockCode = 'winklookup';
-        $this->blockName = esc_html__( "Wink Lookup", "wink2travel" );
-        add_action('init', array( $this,'gutenbergBlockRegistration' ) ); // Adding Gutenberg Block
-        add_shortcode( $this->blockCode, array( $this,'blockHandler') );
-        add_filter('winkShortcodes',array( $this, 'shortcodeData') );
+        $this->blockName = esc_html__( 'Wink Lookup', 'wink2travel' );
+        add_action( 'init', array( $this, 'gutenbergBlockRegistration' ) );
+        add_shortcode( $this->blockCode, array( $this, 'blockHandler' ) );
+        add_filter( 'winkShortcodes', array( $this, 'shortcodeData' ) );
     }
-    function shortcodeData($shortcodes) {
+
+    /**
+     * Provides shortcode metadata for the Customizer settings panel and WPBakery.
+     *
+     * @param  array $shortcodes Existing shortcode definitions.
+     * @return array Shortcode definitions with this element appended.
+     */
+    function shortcodeData( array $shortcodes ): array {
         $shortcodes[] = array(
-            'code' => $this->blockCode,
-            'name' => $this->blockName,
-            'params' => array() 
+            'code'   => $this->blockCode,
+            'name'   => $this->blockName,
+            'params' => array(),
         );
         return $shortcodes;
     }
-    function blockHandler($atts) {
+
+    /**
+     * Outputs the <wink-app-loader> footer component and renders the block HTML.
+     * Used as the render_callback for register_block_type() and as the shortcode handler.
+     *
+     * @param  array|string $atts Block attributes or shortcode attributes (unused for this element).
+     * @return string The rendered HTML for this element.
+     */
+    function blockHandler( $atts ): string {
         $this->coreFunction();
         return $this->winkElement();
     }
-    function winkElement() {
+
+    /**
+     * Returns the HTML for the <wink-lookup> custom element.
+     *
+     * In the Gutenberg editor context the HTML is returned as an escaped string so the
+     * block preview renders the tag text rather than trying to initialise the web component.
+     *
+     * @return string The element HTML.
+     */
+    function winkElement(): string {
         ob_start();
         ?><wink-lookup></wink-lookup><?php
-        $content = ob_get_contents();
-        ob_end_clean();
-        $isAdmin = false;
-        if (!empty($_REQUEST['context']) && $_REQUEST['context'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (!empty($_REQUEST['action']) && $_REQUEST['action'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (is_admin( ) || $isAdmin) { // in editor we should show the raw HTML to make it easier to click on
-            return htmlspecialchars($content);
+        $content = (string) ob_get_clean();
+
+        if ( $this->isEditorContext() ) {
+            return htmlspecialchars( $content );
         }
         return $content;
     }
-
-    function gutenbergBlockRegistration() {
-        // Skip block registration if Gutenberg is not enabled/merged.
-        if (!function_exists('register_block_type')) {
-            return;
-        }
-        
-        $dir = dirname(__FILE__);
-
-        $gutenbergJS = $this->blockCode.'.js';
-        wp_register_script('winkBlockRenderer_'.$this->blockCode, $this->pluginURL . 'elements/js/'.$gutenbergJS,
-            array(
-                'wp-blocks',
-                'wp-i18n',
-                'wp-element',
-                'wp-components',
-                'wp-editor'
-            ),
-            false
-        );
-
-        $jsData = array(
-            'blockCat'  => "wink2travel".'-blocks',
-            'imgURL'    => $this->imgURL,
-            'mode'      => $this->environmentVal
-        );
-
-        wp_localize_script( 'winkBlockRenderer_'.$this->blockCode, 'winkData', $jsData );
-        
-        register_block_type('wink-blocks/'.$this->blockCode, array(
-            'editor_script' => 'winkBlockRenderer_'.$this->blockCode,
-            'render_callback' => array($this,'blockHandler'),
-            'attributes' => [
-                // 'configurationId' => [
-                //     'default' => '',
-                //     'type' => 'string'
-                // ]
-            ],
-            'category' => "wink2travel".'-blocks'
-        ));
-    }
 }
 
-$winkLookup = new winkLookup();
+if ( ! defined( 'WINK_TESTING' ) ) {
+    $winkLookup = new winkLookup();
+}

--- a/includes/elements/winksearch.php
+++ b/includes/elements/winksearch.php
@@ -1,88 +1,101 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/**
+ * Wink Search block element.
+ *
+ * Renders a <wink-search-button> custom element that opens the Wink travel search
+ * interface. Supports Gutenberg blocks, shortcodes, WPBakery, Elementor, and Avada.
+ */
 class winkSearch extends winkElements {
+    /**
+     * Registers the Gutenberg block, shortcode, and Customizer data filter for this element.
+     */
     function __construct() {
         parent::__construct();
         $this->blockCode = 'winksearch';
-        $this->blockName = esc_html__( "Wink Search", "wink2travel" );
-        add_action('init', array( $this,'gutenbergBlockRegistration' ) ); // Adding Gutenberg Block
-        add_shortcode( $this->blockCode, array( $this,'blockHandler') );
-        add_filter('winkShortcodes',array( $this, 'shortcodeData') );
+        $this->blockName = esc_html__( 'Wink Search', 'wink2travel' );
+        add_action( 'init', array( $this, 'gutenbergBlockRegistration' ) );
+        add_shortcode( $this->blockCode, array( $this, 'blockHandler' ) );
+        add_filter( 'winkShortcodes', array( $this, 'shortcodeData' ) );
     }
-    function shortcodeData($shortcodes) {
+
+    /**
+     * Provides shortcode metadata for the Customizer settings panel and WPBakery.
+     *
+     * @param  array $shortcodes Existing shortcode definitions.
+     * @return array Shortcode definitions with this element appended.
+     */
+    function shortcodeData( array $shortcodes ): array {
         $shortcodes[] = array(
-            'code' => $this->blockCode,
-            'name' => $this->blockName,
-            'params' => array() 
+            'code'   => $this->blockCode,
+            'name'   => $this->blockName,
+            'params' => array(),
         );
         return $shortcodes;
     }
-    function blockHandler($atts) {
+
+    /**
+     * Registers the Gutenberg block and schedules the elements stylesheet to be loaded
+     * in the block editor only. Extends the base implementation.
+     *
+     * The stylesheet is registered via the 'enqueue_block_editor_assets' action rather
+     * than during 'init', which would enqueue it on every front-end page load.
+     *
+     * @return void
+     */
+    function gutenbergBlockRegistration(): void {
+        parent::gutenbergBlockRegistration();
+        add_action( 'enqueue_block_editor_assets', array( $this, 'enqueueEditorStyle' ) );
+    }
+
+    /**
+     * Enqueues the elements stylesheet for the Gutenberg block editor.
+     * Hooked to 'enqueue_block_editor_assets'; runs only when the editor is active.
+     *
+     * @return void
+     */
+    function enqueueEditorStyle(): void {
+        wp_enqueue_style(
+            'winkBlockRenderer_' . $this->blockCode,
+            $this->pluginURL . 'elements/css/elements.css',
+            array(),
+            false
+        );
+    }
+
+    /**
+     * Outputs the <wink-app-loader> footer component and renders the block HTML.
+     * Used as the render_callback for register_block_type() and as the shortcode handler.
+     *
+     * @param  array|string $atts Block attributes or shortcode attributes (unused for this element).
+     * @return string The rendered HTML for this element.
+     */
+    function blockHandler( $atts ): string {
         $this->coreFunction();
         return $this->winkElement();
     }
-    function winkElement() {
+
+    /**
+     * Returns the HTML for the <wink-search-button> custom element.
+     *
+     * In the Gutenberg editor context the HTML is returned as an escaped string so the
+     * block preview renders the tag text rather than trying to initialise the web component.
+     *
+     * @return string The element HTML.
+     */
+    function winkElement(): string {
         ob_start();
         ?><wink-search-button></wink-search-button><?php
-        $content = ob_get_contents();
-        ob_end_clean();
-        $isAdmin = false;
-        if (!empty($_REQUEST['context']) && $_REQUEST['context'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (!empty($_REQUEST['action']) && $_REQUEST['action'] == 'edit') {
-            $isAdmin = true;
-        }
-        if (is_admin( ) || $isAdmin) { // in editor we should show the raw HTML to make it easier to click on
-            return htmlspecialchars($content);
+        $content = (string) ob_get_clean();
+
+        if ( $this->isEditorContext() ) {
+            return htmlspecialchars( $content );
         }
         return $content;
     }
-
-    function gutenbergBlockRegistration() {
-        // Skip block registration if Gutenberg is not enabled/merged.
-        if (!function_exists('register_block_type')) {
-            return;
-        }
-        
-        $dir = dirname(__FILE__);
-
-        $gutenbergJS = $this->blockCode.'.js';
-        wp_register_script('winkBlockRenderer_'.$this->blockCode, $this->pluginURL . 'elements/js/'.$gutenbergJS,
-            array(
-                'wp-blocks',
-                'wp-i18n',
-                'wp-element',
-                'wp-components',
-                'wp-editor'
-            ),
-            false
-        );
-        
-
-        $jsData = array(
-            'blockCat'  => "wink2travel".'-blocks',
-            'imgURL'    => $this->imgURL,
-            'mode'      => $this->environmentVal
-        );
-
-        wp_localize_script( 'winkBlockRenderer_'.$this->blockCode, 'winkData', $jsData );
-        
-        wp_enqueue_style(
-            'winkBlockRenderer_'.$this->blockCode, $this->pluginURL . 'elements/css/elements.css', array(), false);
-        register_block_type('wink-blocks/'.$this->blockCode, array(
-            'editor_script' => 'winkBlockRenderer_'.$this->blockCode,
-            'render_callback' => array($this,'blockHandler'),
-            'attributes' => [
-                // 'configurationId' => [
-                //     'default' => '',
-                //     'type' => 'string'
-                // ]
-            ],
-            'category' => "wink2travel".'-blocks'
-        ));
-    }
 }
 
-$winkSearch = new winkSearch();
+if ( ! defined( 'WINK_TESTING' ) ) {
+    $winkSearch = new winkSearch();
+}

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,3 @@
+{
+    "redefinable-internals": ["error_log"]
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    stopOnFailure="false"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>includes</directory>
+            <file>wink.php</file>
+        </include>
+        <exclude>
+            <directory>includes/elements/elementor</directory>
+            <directory>includes/elements/wpbakery</directory>
+            <directory>includes/elements/avada</directory>
+        </exclude>
+    </source>
+</phpunit>

--- a/releaseToMaster.bash
+++ b/releaseToMaster.bash
@@ -4,80 +4,94 @@
 # Copyright (c) wink.travel 2022.
 #
 
+set -e  # Abort immediately if any command fails
+
 echo "Releasing new version of Wink WordPress plugin using git flow..."
 
-versionNumber=$(npx git-changelog-command-line --print-next-version --major-version-pattern BREAKING --minor-version-pattern feat)
+echo "Disabling git messages for a release"
+export GIT_MERGE_AUTOEDIT=no
 
-read -p "Do you want to proceed with version $versionNumber? (y/n) " yn
+# Commit any uncommitted work so the release starts from a clean state
+git commit -a -m "chore: checking in anything in current branch [no ci]" 2>/dev/null || true
+
+echo "Checking out develop branch..."
+git checkout develop
+git pull
+
+CURRENT_VERSION=$(npx git-changelog-command-line --print-next-version --major-version-pattern BREAKING --minor-version-pattern feat)
+PREV_VERSION=$(git describe --tags --abbrev=0)
+
+echo ""
+echo "Previous version : $PREV_VERSION"
+echo "Next version     : $CURRENT_VERSION"
+echo ""
+echo "Unreleased changes:"
+git cliff --unreleased --tag "$CURRENT_VERSION" --sort newest
+echo ""
+
+read -p "Do you want to proceed with version $CURRENT_VERSION? (y/n) " yn
+
+restore_git_autoedit() {
+  export GIT_MERGE_AUTOEDIT=yes
+}
 
 case $yn in
 [yY])
-  echo "Disabling git messages for a release"
-  export GIT_MERGE_AUTOEDIT=no
-
-  git cliff --unreleased --tag $versionNumber --sort newest
-
-  echo "Committing version changes for $versionNumber"
-  sed -i '' "s/Version.*/Version: $versionNumber/g" README.txt
-  sed -i '' "s/Stable tag.*/Stable tag: $versionNumber/g" README.txt
-  sed -i '' "s/Version.*/Version:     $versionNumber/g" wink.php
-
-  git commit -a -m "build: arrow_up: bumping version and merging to master
-
-  Version bump to $versionNumber registered
-
-  Ops: $USER
-  "
+  echo "Bumping version numbers in source files..."
+  sed -i '' "s/Version.*/Version: $CURRENT_VERSION/g" README.txt
+  sed -i '' "s/Stable tag.*/Stable tag: $CURRENT_VERSION/g" README.txt
+  sed -i '' "s/Version.*/Version:     $CURRENT_VERSION/g" wink.php
 
   git push --follow-tags origin develop
 
-  echo "Calling 'git flow release $versionNumber'"
-  git flow release start $versionNumber
+  echo "Starting release branch for $CURRENT_VERSION..."
+  git flow release start "$CURRENT_VERSION"
 
-  echo "Calling 'git flow finish -m $versionNumber $versionNumber'"
-  git flow release finish -m $versionNumber $versionNumber
+  echo "Updating CHANGELOG.md on release branch..."
+  npx git-changelog-command-line -of CHANGELOG.md
+  git commit -a -m "docs: generated changelog and bumped version to $CURRENT_VERSION [no ci]"
+
+  echo "Finishing release $CURRENT_VERSION..."
+  git flow release finish -m "$CURRENT_VERSION [no ci]" "$CURRENT_VERSION"
 
   echo "Checking out master..."
   git checkout master
-
-  echo "Updating CHANGELOG.md..."
-  npx git-changelog-command-line -of CHANGELOG.md
-  git commit -a -m ":memo: doc: Updated CHANGELOG.md..."
-
-  git push origin master:refs/heads/master
-
-  echo "Creating GitHub release..."
-  gh release create v$versionNumber --notes "See CHANGELOG.md for release notes" --target master
-
-  echo "Pulling ORIGIN master into local branch..."
   git pull origin
+  git push
+  git push --tags
 
-  echo "Pushing master (+ tags) to ORIGIN..."
+  echo "Checking out develop..."
+  git checkout develop
+  git pull origin
   git push
 
-  echo "Checking out local develop branch..."
-  git checkout develop
+  echo "Generating release notes from commits since $PREV_VERSION..."
+  git log "$PREV_VERSION".."$CURRENT_VERSION" --pretty=format:"%s" \
+    | grep -v '\[no ci\]' \
+    | sed -E 's/^(feat|fix|chore|docs|style|refactor|perf|test)(\([^)]+\))?: /- \1\2: /' \
+    | grep '^-' \
+    | sort | uniq > release-notes.md
 
-  echo "Pulling ORIGIN develop into local branch..."
-  git pull origin
+  echo "Creating GitHub release v$CURRENT_VERSION..."
+  gh release create "v$CURRENT_VERSION" -F release-notes.md --target master --latest
+  rm release-notes.md
 
   echo "Merging CHANGELOG.md from master into develop..."
   git merge master --no-edit -m ":twisted_rightwards_arrows: doc: merged CHANGELOG.md from master into develop branch" --strategy-option theirs
-
-  echo "Pushing develop to ORIGIN..."
   git push
 
-  echo "Enabling git messages for a release again"
-  export GIT_MERGE_AUTOEDIT=yes
+  restore_git_autoedit
 
-  echo "Wink WordPress plugin $versionNumber has been successfully released"
+  echo "Wink WordPress plugin $CURRENT_VERSION has been successfully released"
   ;;
 [nN])
   echo "Exiting..."
-  exit
+  restore_git_autoedit
+  exit 0
   ;;
 *)
   echo "Invalid response"
+  restore_git_autoedit
   exit 1
   ;;
 esac

--- a/tests/Unit/WinkApiClientTest.php
+++ b/tests/Unit/WinkApiClientTest.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * Tests for WinkApiClient.
+ *
+ * WinkApiClient calls WordPress functions (get_transient, set_transient, wp_remote_post,
+ * wp_remote_get, etc.). Brain\Monkey lets us define what those functions return in each
+ * test without needing a real WordPress installation or a live Wink API.
+ *
+ * Pattern used throughout:
+ *   Monkey\Functions\when('wordpress_function')->justReturn($value)
+ *   — tells Brain\Monkey "whenever this WP function is called, return this value".
+ *
+ * Note: winkCore::environmentURL() is a real static method loaded by the bootstrap,
+ * so it is called directly — Brain\Monkey cannot mock static class methods.
+ */
+
+declare(strict_types=1);
+
+namespace Wink\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class WinkApiClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ── Empty credentials short-circuit ──────────────────────────────────────
+
+    public function test_getLayouts_returns_empty_array_when_clientId_is_empty(): void
+    {
+        $client = new \WinkApiClient('', 'secret', 'production');
+        $result = $client->getLayouts();
+        $this->assertSame([], $result);
+    }
+
+    public function test_getLayouts_returns_empty_array_when_clientSecret_is_empty(): void
+    {
+        $client = new \WinkApiClient('client-id', '', 'production');
+        $result = $client->getLayouts();
+        $this->assertSame([], $result);
+    }
+
+    public function test_getLayouts_returns_empty_array_when_both_credentials_empty(): void
+    {
+        $client = new \WinkApiClient('', '', 'production');
+        $result = $client->getLayouts();
+        $this->assertSame([], $result);
+    }
+
+    // ── Layout cache hit ──────────────────────────────────────────────────────
+
+    public function test_getLayouts_returns_cached_layouts_without_calling_api(): void
+    {
+        $cachedLayouts = [
+            ['id' => 'layout-1', 'name' => 'Hotel Grid', 'layout' => 'HOTEL'],
+            ['id' => 'layout-2', 'name' => 'Tour List',  'layout' => 'TOUR'],
+        ];
+
+        // Transient hit — layouts are in cache, no API call needed.
+        Functions\when('get_transient')->justReturn($cachedLayouts);
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $result = $client->getLayouts();
+
+        $this->assertSame($cachedLayouts, $result);
+    }
+
+    // ── Token cache hit, layout cache miss ────────────────────────────────────
+
+    public function test_getLayouts_uses_cached_bearer_token_when_available(): void
+    {
+        $layouts = [['id' => 'l1', 'name' => 'Hotels', 'layout' => 'HOTEL']];
+
+        // First call: layout transient miss, then bearer token transient hit.
+        Functions\expect('get_transient')
+            ->once()->with('wink_layouts_data')->andReturn(false)
+            ->andAlsoExpectIt()
+            ->once()->with('wink_bearer_token')->andReturn('cached-bearer-token');
+
+        // With the cached token, fetchLayouts is called.
+        // winkCore::environmentURL() is the real implementation from bootstrap.
+        $apiResponse = [
+            'headers'  => [],
+            'body'     => json_encode($layouts),
+            'response' => ['code' => 200],
+        ];
+        Functions\when('wp_remote_get')->justReturn($apiResponse);
+        Functions\when('wp_remote_retrieve_body')->justReturn(json_encode($layouts));
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('set_transient')->justReturn(true);
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $result = $client->getLayouts();
+
+        $this->assertSame($layouts, $result);
+    }
+
+    // ── Token cache miss triggers OAuth request ───────────────────────────────
+
+    public function test_getBearerToken_fetches_new_token_when_cache_empty(): void
+    {
+        $layouts      = [['id' => 'l1', 'name' => 'Hotels', 'layout' => 'HOTEL']];
+        $tokenPayload = json_encode(['access_token' => 'fresh-token', 'expires_in' => 3600]);
+
+        // Both transients miss — need to fetch token then layouts.
+        Functions\expect('get_transient')
+            ->once()->with('wink_layouts_data')->andReturn(false)
+            ->andAlsoExpectIt()
+            ->once()->with('wink_bearer_token')->andReturn(false);
+
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('set_transient')->justReturn(true);
+
+        // OAuth POST response.
+        Functions\when('wp_remote_post')->justReturn(['body' => $tokenPayload]);
+        Functions\when('wp_remote_retrieve_body')
+            ->alias(function($response) use ($tokenPayload, $layouts) {
+                // First call is for the token, second for layouts.
+                static $calls = 0;
+                $calls++;
+                return $calls === 1 ? $tokenPayload : json_encode($layouts);
+            });
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+        Functions\when('wp_remote_get')->justReturn(['body' => json_encode($layouts)]);
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $result = $client->getLayouts();
+
+        $this->assertSame($layouts, $result);
+    }
+
+    // ── OAuth failure throws WinkAuthException ────────────────────────────────
+
+    public function test_getLayouts_throws_WinkAuthException_when_oauth_returns_wp_error(): void
+    {
+        $this->expectException(\WinkAuthException::class);
+        $this->expectExceptionMessageMatches('/OAuth token request failed/');
+
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('wp_remote_post')->justReturn(new \WP_Error('http_request_failed', 'Connection refused'));
+        Functions\when('is_wp_error')->alias(function($v) { return $v instanceof \WP_Error; });
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $client->getLayouts();
+    }
+
+    public function test_getLayouts_throws_WinkAuthException_when_oauth_response_missing_token(): void
+    {
+        $this->expectException(\WinkAuthException::class);
+        $this->expectExceptionMessageMatches('/access_token/');
+
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_post')->justReturn(['body' => json_encode(['error' => 'invalid_client'])]);
+        Functions\when('wp_remote_retrieve_body')->justReturn(json_encode(['error' => 'invalid_client']));
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(401);
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $client->getLayouts();
+    }
+
+    // ── Layout API failure throws WinkDataException ───────────────────────────
+
+    public function test_getLayouts_throws_WinkDataException_when_layout_api_returns_wp_error(): void
+    {
+        $this->expectException(\WinkDataException::class);
+        $this->expectExceptionMessageMatches('/Layout API request failed/');
+
+        // Token is cached so we skip OAuth.
+        Functions\when('get_transient')
+            ->alias(function($key) {
+                return $key === 'wink_bearer_token' ? 'valid-token' : false;
+            });
+
+        Functions\when('wp_remote_get')->justReturn(new \WP_Error('http_request_failed', 'Timeout'));
+        Functions\when('is_wp_error')->alias(function($v) { return $v instanceof \WP_Error; });
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $client->getLayouts();
+    }
+
+    public function test_getLayouts_throws_WinkDataException_on_non_200_http_status(): void
+    {
+        $this->expectException(\WinkDataException::class);
+        $this->expectExceptionMessageMatches('/HTTP 503/');
+
+        Functions\when('get_transient')
+            ->alias(function($key) {
+                return $key === 'wink_bearer_token' ? 'valid-token' : false;
+            });
+
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_get')->justReturn(['body' => '{"error":"maintenance"}']);
+        Functions\when('wp_remote_retrieve_body')->justReturn('{"error":"maintenance"}');
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(503);
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $client->getLayouts();
+    }
+
+    // ── 401 response deletes bearer transient ────────────────────────────────
+
+    public function test_getLayouts_deletes_bearer_transient_on_401_response(): void
+    {
+        $deletedKeys = [];
+
+        Functions\when('get_transient')
+            ->alias(function($key) {
+                return $key === 'wink_bearer_token' ? 'stale-token' : false;
+            });
+
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_get')->justReturn(['body' => '{"message":"Unauthorized"}']);
+        Functions\when('wp_remote_retrieve_body')->justReturn('{"message":"Unauthorized"}');
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(401);
+        Functions\when('delete_transient')->alias(function($key) use (&$deletedKeys) {
+            $deletedKeys[] = $key;
+        });
+
+        try {
+            $client = new \WinkApiClient('client-id', 'secret', 'production');
+            $client->getLayouts();
+        } catch (\WinkAuthException $e) {
+            // Expected.
+        }
+
+        $this->assertContains(
+            'wink_bearer_token',
+            $deletedKeys,
+            'The bearer token transient must be deleted when the API returns 401'
+        );
+    }
+
+    // ── Successful layouts are cached ─────────────────────────────────────────
+
+    public function test_getLayouts_caches_result_with_WINK_CACHE_TTL(): void
+    {
+        $layouts = [['id' => 'l1', 'name' => 'Hotels', 'layout' => 'HOTEL']];
+        $setCalls = [];
+
+        Functions\when('get_transient')
+            ->alias(function($key) {
+                return $key === 'wink_bearer_token' ? 'valid-token' : false;
+            });
+
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_get')->justReturn(['body' => json_encode($layouts)]);
+        Functions\when('wp_remote_retrieve_body')->justReturn(json_encode($layouts));
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+        Functions\when('set_transient')->alias(function($key, $value, $ttl) use (&$setCalls) {
+            $setCalls[] = ['key' => $key, 'ttl' => $ttl];
+        });
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $client->getLayouts();
+
+        $layoutCache = array_filter($setCalls, fn($c) => $c['key'] === 'wink_layouts_data');
+        $this->assertNotEmpty($layoutCache, 'Layout data should be cached');
+
+        $cached = array_values($layoutCache)[0];
+        $this->assertSame(WINK_CACHE_TTL, $cached['ttl'], 'TTL should equal WINK_CACHE_TTL constant');
+    }
+
+    // ── SSL verification disabled only for development ────────────────────────
+
+    public function test_ssl_verification_enabled_for_production(): void
+    {
+        $capturedArgs = [];
+
+        Functions\when('get_transient')
+            ->alias(function($key) {
+                return $key === 'wink_bearer_token' ? 'valid-token' : false;
+            });
+
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('wp_remote_get')->alias(function($url, $args) use (&$capturedArgs) {
+            $capturedArgs = $args;
+            return ['body' => '[]'];
+        });
+        Functions\when('wp_remote_retrieve_body')->justReturn('[]');
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+        Functions\when('set_transient')->justReturn(true);
+
+        $client = new \WinkApiClient('client-id', 'secret', 'production');
+        $client->getLayouts();
+
+        $this->assertTrue($capturedArgs['sslverify'], 'SSL verification must be enabled for production');
+    }
+
+    public function test_ssl_verification_disabled_for_development(): void
+    {
+        $capturedArgs = [];
+
+        Functions\when('get_transient')
+            ->alias(function($key) {
+                return $key === 'wink_bearer_token' ? 'valid-token' : false;
+            });
+
+        Functions\when('is_wp_error')->justReturn(false);
+        Functions\when('error_log')->justReturn(null);
+        Functions\when('wp_remote_get')->alias(function($url, $args) use (&$capturedArgs) {
+            $capturedArgs = $args;
+            return ['body' => '[]'];
+        });
+        Functions\when('wp_remote_retrieve_body')->justReturn('[]');
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(200);
+        Functions\when('set_transient')->justReturn(true);
+
+        $client = new \WinkApiClient('client-id', 'secret', 'development');
+        $client->getLayouts();
+
+        $this->assertFalse($capturedArgs['sslverify'], 'SSL verification must be disabled for development');
+    }
+}

--- a/tests/Unit/WinkCacheClearTest.php
+++ b/tests/Unit/WinkCacheClearTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Tests for wink::clearwinkCache().
+ *
+ * Verifies that clearing the cache:
+ * - Requires the manage_options capability (access control)
+ * - Deletes all four transient and option keys
+ * - Does nothing when called by a non-admin user
+ */
+
+declare(strict_types=1);
+
+namespace Wink\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Minimal testable subclass that exposes clearwinkCache() without running
+ * the full wink constructor (which registers WordPress hooks and reads options).
+ */
+class TestableWink extends \wink
+{
+    public function __construct()
+    {
+        // Intentionally skip parent::__construct() to avoid hook registration.
+        // Only the properties needed by clearwinkCache() are initialised.
+    }
+
+    public function clearwinkCachePublic(): void
+    {
+        $this->clearwinkCache();
+    }
+}
+
+class WinkCacheClearTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_clearwinkCache_deletes_all_transients_and_options_for_admin(): void
+    {
+        Functions\when('current_user_can')->justReturn(true);
+
+        $deleted = [];
+        Functions\when('delete_transient')->alias(function($key) use (&$deleted) { $deleted[] = $key; });
+        Functions\when('delete_option')->alias(function($key) use (&$deleted) { $deleted[] = $key; });
+
+        (new TestableWink())->clearwinkCachePublic();
+
+        $this->assertContains('wink_bearer_token',  $deleted);
+        $this->assertContains('wink_layouts_data',  $deleted);
+        $this->assertContains('wink_auth_error',    $deleted);
+        $this->assertContains('winkData',           $deleted);
+        $this->assertContains('winkdataTime',       $deleted);
+        $this->assertContains('winkcontentTime',    $deleted);
+        $this->assertContains('winkcontentBearer',  $deleted);
+    }
+
+    public function test_clearwinkCache_does_nothing_for_non_admin(): void
+    {
+        Functions\when('current_user_can')->justReturn(false);
+
+        $deleted = [];
+        Functions\when('delete_transient')->alias(function($key) use (&$deleted) { $deleted[] = $key; });
+        Functions\when('delete_option')->alias(function($key) use (&$deleted) { $deleted[] = $key; });
+
+        (new TestableWink())->clearwinkCachePublic();
+
+        $this->assertEmpty($deleted, 'Non-admin must not be able to clear the cache');
+    }
+
+    public function test_clearwinkCache_deletes_exactly_seven_keys(): void
+    {
+        Functions\when('current_user_can')->justReturn(true);
+
+        $deleted = [];
+        Functions\when('delete_transient')->alias(function($key) use (&$deleted) { $deleted[] = $key; });
+        Functions\when('delete_option')->alias(function($key) use (&$deleted) { $deleted[] = $key; });
+
+        (new TestableWink())->clearwinkCachePublic();
+
+        $this->assertCount(7, $deleted, 'Expected exactly 7 keys to be deleted');
+    }
+}

--- a/tests/Unit/WinkContentTest.php
+++ b/tests/Unit/WinkContentTest.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Tests for winkContent::winkElement() and winkContent::resolveLayoutType().
+ *
+ * These tests verify the HTML rendering logic and how the block handles:
+ * - Known / unknown layout IDs
+ * - The WPBakery lowercase 'layoutid' attribute alias
+ * - Editor-context detection (should return escaped HTML)
+ * - API failure fallback behaviour (should return 'HOTEL' default)
+ * - The "escape late" security contract (esc_attr applied at output, not input)
+ */
+
+declare(strict_types=1);
+
+namespace Wink\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use Mockery;
+
+/**
+ * Concrete test subclass of winkContent that bypasses the constructor's WordPress
+ * hook registration and WinkApiClient instantiation, substituting a mock client.
+ */
+class TestableWinkContent extends \winkContent
+{
+    public \WinkApiClient $apiClient;
+
+    public function __construct(\WinkApiClient $apiClient)
+    {
+        // Skip parent::__construct() entirely — it calls add_action, add_shortcode,
+        // get_option, etc. which are not relevant here. Set the minimum properties.
+        $this->blockCode      = 'winkcontent';
+        $this->blockName      = 'wink Content';
+        $this->attributes     = [];
+        $this->pluginURL      = 'https://example.com/wp-content/plugins/wink/includes/';
+        $this->imgURL         = 'https://example.com/wp-content/plugins/wink/img/';
+        $this->environmentVal = 'production';
+        $this->clientIdKey    = WINK_CLIENT_ID_OPTION;
+        $this->clientSecretKey = 'winkSecret';
+        $this->apiClient      = $apiClient;
+    }
+
+    // Expose the protected resolveLayoutType() for direct testing.
+    public function resolveLayoutTypePublic(string $layoutId): string
+    {
+        return $this->resolveLayoutType($layoutId);
+    }
+}
+
+// elementHandler.php (winkElements base class) is loaded by tests/bootstrap.php.
+require_once dirname(__DIR__, 2) . '/includes/elements/winkcontent.php';
+
+class WinkContentTest extends TestCase
+{
+    private \WinkApiClient $mockApiClient;
+    private TestableWinkContent $content;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        // Stub WordPress escaping functions used by winkElement().
+        Functions\when('esc_attr')->alias(fn($v) => htmlspecialchars((string) $v, ENT_QUOTES));
+        Functions\when('esc_html')->alias(fn($v) => htmlspecialchars((string) $v, ENT_QUOTES));
+        Functions\when('is_admin')->justReturn(false);
+        Functions\when('sanitize_key')->alias(fn($v) => strtolower(preg_replace('/[^a-z0-9_\-]/i', '', $v)));
+        Functions\when('error_log')->justReturn(null);
+        Functions\when('set_transient')->justReturn(true);
+
+        $this->mockApiClient = Mockery::mock(\WinkApiClient::class);
+        $this->content       = new TestableWinkContent($this->mockApiClient);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ── winkElement: basic attribute rendering ────────────────────────────────
+
+    public function test_winkElement_renders_content_loader_tag(): void
+    {
+        $output = $this->content->winkElement([]);
+        $this->assertStringContainsString('<wink-content-loader', $output);
+        $this->assertStringContainsString('</wink-content-loader>', $output);
+    }
+
+    public function test_winkElement_includes_layout_attribute_when_provided(): void
+    {
+        $output = $this->content->winkElement(['layout' => 'HOTEL']);
+        $this->assertStringContainsString('layout="HOTEL"', $output);
+    }
+
+    public function test_winkElement_includes_id_attribute_when_layoutId_provided(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')->andReturn([]);
+        $output = $this->content->winkElement(['layoutId' => 'abc-123']);
+        $this->assertStringContainsString('id="abc-123"', $output);
+    }
+
+    // ── winkElement: WPBakery lowercase alias ─────────────────────────────────
+
+    public function test_winkElement_accepts_lowercase_layoutid_from_wpbakery(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')->andReturn([]);
+        $output = $this->content->winkElement(['layoutid' => 'wpb-layout-id']);
+        $this->assertStringContainsString('id="wpb-layout-id"', $output);
+    }
+
+    // ── winkElement: layout type resolution ───────────────────────────────────
+
+    public function test_winkElement_resolves_layout_type_from_api_when_only_id_given(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')->once()->andReturn([
+            ['id' => 'abc-123', 'name' => 'Hotels', 'layout' => 'HOTEL'],
+            ['id' => 'def-456', 'name' => 'Tours',  'layout' => 'TOUR'],
+        ]);
+
+        $output = $this->content->winkElement(['layoutId' => 'def-456']);
+        $this->assertStringContainsString('layout="TOUR"', $output);
+    }
+
+    public function test_winkElement_uses_explicit_layout_attribute_without_api_call(): void
+    {
+        // getLayouts should NOT be called when 'layout' is explicitly provided without 'layoutId'.
+        $this->mockApiClient->shouldNotReceive('getLayouts');
+
+        $output = $this->content->winkElement(['layout' => 'ACTIVITY']);
+        $this->assertStringContainsString('layout="ACTIVITY"', $output);
+    }
+
+    public function test_winkElement_defaults_to_HOTEL_when_layout_id_not_in_api_results(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')->andReturn([
+            ['id' => 'different-id', 'name' => 'Hotels', 'layout' => 'HOTEL'],
+        ]);
+
+        $output = $this->content->winkElement(['layoutId' => 'unknown-id']);
+        $this->assertStringContainsString('layout="HOTEL"', $output);
+    }
+
+    // ── winkElement: editor context ───────────────────────────────────────────
+
+    public function test_winkElement_returns_escaped_html_in_editor_context(): void
+    {
+        // Simulate Gutenberg editor REST request.
+        $_REQUEST['context'] = 'edit';
+
+        $output = $this->content->winkElement([]);
+
+        // In editor mode the tag should be HTML-entity-escaped so the browser
+        // renders the tag text rather than initialising the web component.
+        $this->assertStringContainsString('&lt;wink-content-loader', $output);
+        $this->assertStringNotContainsString('<wink-content-loader>', $output);
+
+        unset($_REQUEST['context']);
+    }
+
+    public function test_winkElement_returns_raw_html_outside_editor(): void
+    {
+        Functions\when('is_admin')->justReturn(false);
+        unset($_REQUEST['context'], $_REQUEST['action']);
+
+        $output = $this->content->winkElement([]);
+        $this->assertStringContainsString('<wink-content-loader', $output);
+        $this->assertStringNotContainsString('&lt;wink-content-loader', $output);
+    }
+
+    // ── winkElement: XSS / escaping contract ─────────────────────────────────
+
+    public function test_winkElement_escapes_layout_attribute_value(): void
+    {
+        // If somehow a layout attribute contained a quote, it must be encoded.
+        $malicious = 'HOTEL" onload="alert(1)';
+        $output = $this->content->winkElement(['layout' => $malicious]);
+
+        // The raw quote must not appear in the output.
+        $this->assertStringNotContainsString('"HOTEL" onload', $output);
+        // But the value should still be present in escaped form.
+        $this->assertStringContainsString('HOTEL', $output);
+    }
+
+    public function test_winkElement_escapes_id_attribute_value(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')->andReturn([]);
+        $malicious = 'id"><script>alert(1)</script>';
+        $output = $this->content->winkElement(['layoutId' => $malicious]);
+
+        $this->assertStringNotContainsString('<script>', $output);
+    }
+
+    // ── resolveLayoutType: direct tests ──────────────────────────────────────
+
+    public function test_resolveLayoutType_returns_layout_for_matching_id(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')->andReturn([
+            ['id' => 'tour-1', 'name' => 'Tours', 'layout' => 'TOUR'],
+        ]);
+
+        $result = $this->content->resolveLayoutTypePublic('tour-1');
+        $this->assertSame('TOUR', $result);
+    }
+
+    public function test_resolveLayoutType_returns_HOTEL_when_no_match(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')->andReturn([
+            ['id' => 'something-else', 'name' => 'Other', 'layout' => 'ACTIVITY'],
+        ]);
+
+        $result = $this->content->resolveLayoutTypePublic('non-existent');
+        $this->assertSame('HOTEL', $result);
+    }
+
+    public function test_resolveLayoutType_returns_HOTEL_when_layout_field_empty(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')->andReturn([
+            ['id' => 'layout-x', 'name' => 'Unknown', 'layout' => ''],
+        ]);
+
+        $result = $this->content->resolveLayoutTypePublic('layout-x');
+        $this->assertSame('HOTEL', $result);
+    }
+
+    public function test_resolveLayoutType_returns_HOTEL_on_WinkAuthException(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')
+            ->andThrow(new \WinkAuthException('bad credentials'));
+
+        Functions\when('set_transient')->justReturn(true);
+
+        $result = $this->content->resolveLayoutTypePublic('any-id');
+        $this->assertSame('HOTEL', $result);
+    }
+
+    public function test_resolveLayoutType_sets_auth_error_transient_on_WinkAuthException(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')
+            ->andThrow(new \WinkAuthException('OAuth failed'));
+
+        $transientKey   = null;
+        $transientValue = null;
+        Functions\when('set_transient')->alias(function($key, $value) use (&$transientKey, &$transientValue) {
+            $transientKey   = $key;
+            $transientValue = $value;
+        });
+
+        $this->content->resolveLayoutTypePublic('any-id');
+
+        $this->assertSame('wink_auth_error', $transientKey);
+        $this->assertSame('OAuth failed', $transientValue);
+    }
+
+    public function test_resolveLayoutType_returns_HOTEL_on_WinkDataException(): void
+    {
+        $this->mockApiClient->shouldReceive('getLayouts')
+            ->andThrow(new \WinkDataException('API timeout'));
+
+        $result = $this->content->resolveLayoutTypePublic('any-id');
+        $this->assertSame('HOTEL', $result);
+    }
+}

--- a/tests/Unit/WinkCoreTest.php
+++ b/tests/Unit/WinkCoreTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Tests for winkCore::environmentURL().
+ *
+ * This is the simplest unit test target in the codebase: a pure static method that
+ * takes two strings and returns a URL. No WordPress functions, no database, no mocks.
+ */
+
+declare(strict_types=1);
+
+namespace Wink\Tests\Unit;
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
+
+// wink.php (and therefore winkCore) is loaded by tests/bootstrap.php.
+
+class WinkCoreTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    // ── Production environment ────────────────────────────────────────────────
+
+    public function test_production_js_url(): void
+    {
+        $this->assertSame(
+            'https://elements.wink.travel',
+            \winkCore::environmentURL('js', 'production')
+        );
+    }
+
+    public function test_production_json_url(): void
+    {
+        $this->assertSame(
+            'https://iam.wink.travel',
+            \winkCore::environmentURL('json', 'production')
+        );
+    }
+
+    public function test_production_api_url(): void
+    {
+        $this->assertSame(
+            'https://api.wink.travel',
+            \winkCore::environmentURL('api', 'production')
+        );
+    }
+
+    // ── Staging environment ───────────────────────────────────────────────────
+
+    public function test_staging_js_url(): void
+    {
+        $this->assertSame(
+            'https://staging-elements.wink.travel',
+            \winkCore::environmentURL('js', 'staging')
+        );
+    }
+
+    public function test_staging_json_url(): void
+    {
+        $this->assertSame(
+            'https://staging-iam.wink.travel',
+            \winkCore::environmentURL('json', 'staging')
+        );
+    }
+
+    public function test_staging_api_url(): void
+    {
+        $this->assertSame(
+            'https://staging-api.wink.travel',
+            \winkCore::environmentURL('api', 'staging')
+        );
+    }
+
+    // ── Development environment ───────────────────────────────────────────────
+
+    public function test_development_js_url(): void
+    {
+        $this->assertSame(
+            'https://dev.traveliko.com:8011',
+            \winkCore::environmentURL('js', 'development')
+        );
+    }
+
+    public function test_development_json_url(): void
+    {
+        $this->assertSame(
+            'https://dev.traveliko.com:9000',
+            \winkCore::environmentURL('json', 'development')
+        );
+    }
+
+    public function test_development_api_url(): void
+    {
+        $this->assertSame(
+            'https://dev.traveliko.com:8443',
+            \winkCore::environmentURL('api', 'development')
+        );
+    }
+
+    // ── Unknown environment falls back to production ──────────────────────────
+
+    public function test_unknown_environment_defaults_to_production_js(): void
+    {
+        // An unrecognised environment (e.g. a typo like 'prod') must not crash the
+        // site — the match default arm returns production URLs safely.
+        $this->assertSame(
+            'https://elements.wink.travel',
+            \winkCore::environmentURL('js', 'prod')
+        );
+    }
+
+    public function test_unknown_environment_defaults_to_production_api(): void
+    {
+        $this->assertSame(
+            'https://api.wink.travel',
+            \winkCore::environmentURL('api', 'anything_unexpected')
+        );
+    }
+
+    // ── Unknown target throws ─────────────────────────────────────────────────
+
+    public function test_unknown_target_throws_invalid_argument_exception(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        \winkCore::environmentURL('ftp', 'production');
+    }
+
+    public function test_unknown_target_in_staging_throws(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        \winkCore::environmentURL('css', 'staging');
+    }
+
+    // ── Return type is always a non-empty string ──────────────────────────────
+
+    public function test_all_known_combinations_return_non_empty_strings(): void
+    {
+        $targets      = ['js', 'json', 'api'];
+        $environments = ['production', 'staging', 'development'];
+
+        foreach ($environments as $env) {
+            foreach ($targets as $target) {
+                $url = \winkCore::environmentURL($target, $env);
+                $this->assertIsString($url, "{$target}/{$env} should return a string");
+                $this->assertNotEmpty($url, "{$target}/{$env} should not be empty");
+                $this->assertStringStartsWith('https://', $url, "{$target}/{$env} should be HTTPS");
+            }
+        }
+    }
+}

--- a/tests/Unit/WinkExceptionTest.php
+++ b/tests/Unit/WinkExceptionTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests for the WinkException hierarchy.
+ *
+ * Verifies that the exception types are related correctly so that catch blocks
+ * that catch the base class also catch the subtypes, and that each type carries
+ * the correct message through to the catch site.
+ */
+
+declare(strict_types=1);
+
+namespace Wink\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class WinkExceptionTest extends TestCase
+{
+    // ── Inheritance structure ─────────────────────────────────────────────────
+
+    public function test_WinkAuthException_is_a_WinkApiException(): void
+    {
+        $e = new \WinkAuthException('bad credentials');
+        $this->assertInstanceOf(\WinkApiException::class, $e);
+    }
+
+    public function test_WinkDataException_is_a_WinkApiException(): void
+    {
+        $e = new \WinkDataException('api error');
+        $this->assertInstanceOf(\WinkApiException::class, $e);
+    }
+
+    public function test_WinkApiException_is_a_RuntimeException(): void
+    {
+        $e = new \WinkApiException('base error');
+        $this->assertInstanceOf(\RuntimeException::class, $e);
+    }
+
+    // ── Catch-by-base-type works ──────────────────────────────────────────────
+
+    public function test_catch_base_type_catches_WinkAuthException(): void
+    {
+        $caught = null;
+        try {
+            throw new \WinkAuthException('token rejected');
+        } catch (\WinkApiException $e) {
+            $caught = $e;
+        }
+        $this->assertNotNull($caught);
+        $this->assertSame('token rejected', $caught->getMessage());
+    }
+
+    public function test_catch_base_type_catches_WinkDataException(): void
+    {
+        $caught = null;
+        try {
+            throw new \WinkDataException('layout fetch failed');
+        } catch (\WinkApiException $e) {
+            $caught = $e;
+        }
+        $this->assertNotNull($caught);
+        $this->assertSame('layout fetch failed', $caught->getMessage());
+    }
+
+    // ── Selective catch works ─────────────────────────────────────────────────
+
+    public function test_WinkDataException_is_not_caught_as_WinkAuthException(): void
+    {
+        $caughtAuth = false;
+        $caughtData = false;
+        try {
+            throw new \WinkDataException('data error');
+        } catch (\WinkAuthException $e) {
+            $caughtAuth = true;
+        } catch (\WinkDataException $e) {
+            $caughtData = true;
+        }
+        $this->assertFalse($caughtAuth, 'WinkDataException must not be caught as WinkAuthException');
+        $this->assertTrue($caughtData);
+    }
+
+    // ── Message is preserved ──────────────────────────────────────────────────
+
+    public function test_exception_message_is_preserved(): void
+    {
+        $message = 'OAuth token request failed: Connection timed out';
+        $e = new \WinkAuthException($message);
+        $this->assertSame($message, $e->getMessage());
+    }
+
+    public function test_exception_code_is_preserved(): void
+    {
+        $e = new \WinkDataException('error', 503);
+        $this->assertSame(503, $e->getCode());
+    }
+
+    public function test_previous_exception_is_preserved(): void
+    {
+        $original = new \RuntimeException('connection refused');
+        $e = new \WinkAuthException('wrapped', 0, $original);
+        $this->assertSame($original, $e->getPrevious());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * PHPUnit bootstrap for the Wink WordPress Plugin test suite.
+ *
+ * Sets up Brain\Monkey (which provides stubs for WordPress functions like get_option,
+ * esc_attr, etc.) and defines the constants and classes the plugin code expects to
+ * find when it loads. This lets tests run without a real WordPress installation.
+ *
+ * WINK_TESTING is defined first so that plugin files can be loaded for their class
+ * definitions without running constructors, registering hooks, or calling WordPress
+ * functions. This mirrors the WP_UNINSTALL_PLUGIN pattern used in WordPress core.
+ */
+
+// Autoload Composer packages (PHPUnit, Brain\Monkey, Mockery).
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tell all plugin files to skip instantiation at module load time.
+// ──────────────────────────────────────────────────────────────────────────────
+define('WINK_TESTING', true);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// WordPress constants expected by the plugin source files.
+// ──────────────────────────────────────────────────────────────────────────────
+define('ABSPATH', '/fake/wordpress/');
+define('HOUR_IN_SECONDS', 3600);
+
+// Plugin constants defined in wink.php.
+// We define them here so individual source files can be loaded in isolation.
+if (!defined('WINK_CACHE_TTL')) {
+    define('WINK_CACHE_TTL', 120);
+}
+if (!defined('WINK_CLIENT_ID_OPTION')) {
+    define('WINK_CLIENT_ID_OPTION', 'winkClientId');
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Stub WordPress classes needed by type declarations in the plugin.
+// ──────────────────────────────────────────────────────────────────────────────
+if (!class_exists('WP_Post')) {
+    class WP_Post {
+        public int    $ID           = 0;
+        public string $post_content = '';
+        public string $post_type    = 'post';
+    }
+}
+
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        private string $message;
+        public function __construct(string $code = '', string $message = '') {
+            $this->message = $message;
+        }
+        public function get_error_message(): string { return $this->message; }
+    }
+}
+
+if (!class_exists('WP_Customize_Manager')) {
+    class WP_Customize_Manager {
+        public function add_section(string $id, array $args = []): void {}
+        public function add_setting(string $id, array $args = []): void {}
+        public function add_control(string $id, array $args = []): void {}
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Load the plugin source files that tests will exercise.
+//
+// Loading order matters: exceptions and the API client must exist before any
+// class that uses them in a property declaration is parsed.
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Exception hierarchy — no dependencies.
+require_once dirname(__DIR__) . '/includes/WinkException.php';
+
+// API client — depends on WinkException; also needs winkCore::environmentURL()
+// which is defined in wink.php after the wink class.
+require_once dirname(__DIR__) . '/includes/WinkApiClient.php';
+
+// wink and winkCore class definitions. WINK_TESTING prevents `new wink()` and
+// the `require_once 'includes/elementHandler.php'` conditional from running.
+require_once dirname(__DIR__) . '/wink.php';
+
+// elementHandler.php defines the winkElements base class that winkContent
+// extends. Load it unconditionally here (the WINK_TESTING guard in wink.php
+// skips loading it via the get_option conditional).
+require_once dirname(__DIR__) . '/includes/elementHandler.php';

--- a/wink.php
+++ b/wink.php
@@ -17,212 +17,390 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Wink Affiliate WordPress plugin. If not, see https://www.gnu.org/licenses/gpl-2.0.html.
  */
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/** Cache lifetime in seconds for Wink layout data fetched from the Wink API. */
+if ( ! defined( 'WINK_CACHE_TTL' ) ) {
+    define( 'WINK_CACHE_TTL', 120 );
+}
+
+/**
+ * WordPress option key used to store the Wink affiliate Client ID.
+ * Defined as a constant so that the plugin bootstrap (require_once guard below),
+ * the wink class, and the winkElements base class all reference the same string.
+ */
+if ( ! defined( 'WINK_CLIENT_ID_OPTION' ) ) {
+    define( 'WINK_CLIENT_ID_OPTION', 'winkClientId' );
+}
+
+/**
+ * Main plugin class. Handles initialization, Customizer settings registration,
+ * Gutenberg block category registration, front-end script enqueueing, and admin notices.
+ *
+ * Instantiated once at plugin load time via `new wink()` at the bottom of this file.
+ */
 class wink {
+    private string $version;
+    private string $section;
+    private string $clientIdKey;
+    private string $clientSecretKey;
+    private string $environment;
+    private string $environmentVal;
+    private string $pluginURL;
+    private string $settingsURL;
+
+    /**
+     * Registers all WordPress hooks needed by the plugin.
+     */
     function __construct() {
-        $this->version = current_time('Y-m-d');
-        $this->section = 'wink'; // Customizer Section Name
-        $this->clientIdKey = 'winkClientId';
+        $this->version         = current_time( 'Y-m-d' );
+        $this->section         = 'wink';
+        $this->clientIdKey     = WINK_CLIENT_ID_OPTION;
         $this->clientSecretKey = 'winkSecret';
-        $this->environment = 'winkEnvironment';
-        $this->environmentVal = get_option($this->environment, 'production');
-        $this->pluginURL = esc_url(trailingslashit( plugin_dir_url( __FILE__ ) ) );
-        $this->settingsURL = esc_url(admin_url( '/customize.php?autofocus[section]='.$this->section));
-        add_action( 'customize_register', array( $this,'addSettings' ) ); // adding plugin settings to WP Customizer
-        add_action('admin_notices', array( $this,'adminNotice' ) ); // adding admin notice if client id has not been entered
-        //add_shortcode('wink', array( $this,'blockHandler' ) ); // Adding Shortcode
-        add_filter( 'block_categories_all', array( $this,'gutenbergBlockCategory' ), 10, 2); // Adding custom Gutenberg Block Category
-        //add_action('init', array( $this,'gutenbergBlockRegistration' ) ); // Adding Gutenberg Block
-        add_action( 'wp_enqueue_scripts', array($this, 'loadScripts' )); // too resource intensive to search all pages for Wink elements. Scripts need to be added all the time.
-        
-        add_filter( 'script_loader_tag', array($this,'jsHelper'), 11, 3 ); // Helper to add attribute to js tag
-        add_action( 'admin_enqueue_scripts', array($this,'customizeScripts'));
+        $this->environment     = 'winkEnvironment';
+        $this->environmentVal  = (string) get_option( $this->environment, 'production' );
+        $this->pluginURL       = esc_url( trailingslashit( plugin_dir_url( __FILE__ ) ) );
+        $this->settingsURL     = esc_url( admin_url( '/customize.php?autofocus[section]=' . $this->section ) );
 
-        add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), array($this,'settingsLink' ));
-
-        add_action( 'customize_save_after' , array($this, 'clearwinkCache' ));
+        add_action( 'customize_register',   array( $this, 'addSettings' ) );
+        add_action( 'admin_notices',        array( $this, 'adminNotice' ) );
+        add_filter( 'block_categories_all', array( $this, 'gutenbergBlockCategory' ), 10, 2 );
+        add_action( 'wp_enqueue_scripts',   array( $this, 'loadScripts' ) );
+        add_filter( 'script_loader_tag',    array( $this, 'jsHelper' ), 11, 3 );
+        add_action( 'admin_enqueue_scripts', array( $this, 'customizeScripts' ) );
+        add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'settingsLink' ) );
+        add_action( 'customize_save_after', array( $this, 'clearwinkCache' ) );
     }
 
-    function settingsLink( $links ) {
-        // Build and escape the URL.
-        $url = esc_url( add_query_arg(
-            'page',
-            'nelio-content-settings',
-            get_admin_url() . 'admin.php'
-        ) );
-        // Create the link.
-        $settings_link = '<a href="'.esc_url($this->settingsURL).'" title="'.esc_html__('Wink settings',"wink2travel").'">' . esc_html__( 'Settings',"wink2travel" ) . '</a>';
-        // Adds the link to the end of the array.
-        array_push(
-            $links,
-            $settings_link
-        );
+    /**
+     * Adds a "Settings" link to the plugin's row on the Plugins admin page.
+     *
+     * @param  array $links Existing action links for this plugin.
+     * @return array Action links with the Settings link appended.
+     */
+    function settingsLink( array $links ): array {
+        $settings_link = '<a href="' . esc_url( $this->settingsURL ) . '" title="' . esc_html__( 'Wink settings', 'wink2travel' ) . '">'
+            . esc_html__( 'Settings', 'wink2travel' ) . '</a>';
+        array_push( $links, $settings_link );
         return $links;
     }
-    function customizeScripts() {
-        if (!isset($_GET['winkadmin']) && !isset($_GET['winkAdmin'])) {
+
+    /**
+     * Enqueues the Customizer admin stylesheet, unless the winkadmin flag is present in the URL.
+     *
+     * @return void
+     */
+    function customizeScripts(): void {
+        if ( ! isset( $_GET['winkadmin'] ) && ! isset( $_GET['winkAdmin'] ) ) {
             wp_enqueue_style( 'winkCustomizer', $this->pluginURL . 'css/customize.css', array(), $this->version );
         }
     }
-    function jsHelper($tag, $handle, $src) {
-        $env = winkCore::environmentURL('js', $this->environmentVal);
-        $optimize = array(
-            'wink-Elements',
-            'wink-Elements-Poly',
-            'wink-Elements-main'
-        );
-        if ( in_array( $handle, $optimize ) ) { // this will be optimized
+
+    /**
+     * Modifies the script tag for Wink CDN scripts to add type="module" and defer attributes,
+     * which tells the browser to load the script asynchronously without blocking page rendering.
+     *
+     * @param  string $tag    The complete HTML script tag.
+     * @param  string $handle The registered script handle.
+     * @param  string $src    The script source URL.
+     * @return string The original or modified script tag.
+     */
+    function jsHelper( string $tag, string $handle, string $src ): string {
+        $optimize = array( 'wink-Elements', 'wink-Elements-Poly', 'wink-Elements-main' );
+        if ( in_array( $handle, $optimize, true ) ) {
             $tag = '<script type="module" src="' . esc_url( $src ) . '" defer data-cfasync="true"></script>';
         }
         return $tag;
     }
 
-    function loadScripts() {
-        if (!empty(get_option($this->clientIdKey, false))) {
-            $env = winkCore::environmentURL('js', $this->environmentVal);
-            wp_enqueue_style('wink',$env.'/styles.css',array(),$this->version);
-            wp_enqueue_script('wink-Elements',$env.'/elements.js',array(),$this->version,true);
-            // wp_enqueue_script('wink-Elements-Poly',$env.'/polyfills.js',array(),$this->version,true);
-            // wp_enqueue_script('wink-Elements-main',$env.'/main.js',array(),$this->version,true);
+    /**
+     * Enqueues the Wink front-end JavaScript and CSS from the Wink CDN when a client ID is set.
+     *
+     * Skips loading on singular pages that contain no Wink blocks or shortcodes.
+     * Always loads on archive/home pages and when Elementor is active (Elementor stores
+     * its data in post meta, which cannot be reliably checked here).
+     *
+     * @return void
+     */
+    function loadScripts(): void {
+        if ( empty( get_option( $this->clientIdKey, false ) ) ) {
+            return;
         }
+        if ( is_singular() && ! $this->currentPageHasWinkContent() ) {
+            return;
+        }
+        $env = winkCore::environmentURL( 'js', $this->environmentVal );
+        wp_enqueue_style( 'wink', $env . '/styles.css', array(), $this->version );
+        wp_enqueue_script( 'wink-Elements', $env . '/elements.js', array(), $this->version, true );
     }
-    function adminNotice() {
-        if (is_admin() && !get_option($this->clientIdKey, false)) {
-            if ( current_user_can( 'manage_options' ) ) { // let's only show this to admin users
-                echo '<div class="notice notice-info">
-                <img src="'.esc_url($this->pluginURL).'img/logo.png" alt="'.esc_html__('Wink logo',"wink2travel").'" width="100" style="margin-top: 10px;"><p><b>'.
-                esc_html__('Congratulations', "wink2travel").
-                '</b> '.
-                esc_html__('on installing the official Wink Affiliate WordPress plugin.',"wink2travel").
-                ' <a href="'.esc_url($this->settingsURL).'" title="'.esc_html__('Wink settings',"wink2travel").'">'.
-                esc_html__('Click here',"wink2travel").
-                '</a> '.
-                esc_html__('to add your Wink Client-ID and your Client-Secret',"wink2travel").
-                '.</p>
-                </div>';
+
+    /**
+     * Checks whether the current singular page or post contains any Wink block or shortcode.
+     *
+     * Returns true (load scripts) whenever detection is not possible — for example when
+     * Elementor is active, because Elementor stores its widget data in post meta rather
+     * than in post_content, making has_block() and has_shortcode() unreliable.
+     *
+     * @return bool True if Wink content is detected or cannot be determined; false otherwise.
+     */
+    private function currentPageHasWinkContent(): bool {
+        // When Elementor is active its content is in post meta, not post_content — always load.
+        if ( defined( 'ELEMENTOR_VERSION' ) ) {
+            return true;
+        }
+
+        $post = get_post();
+        if ( ! $post instanceof WP_Post ) {
+            return true; // Cannot determine — load scripts to be safe.
+        }
+
+        $blocks = array(
+            'wink-blocks/winklookup',
+            'wink-blocks/winksearch',
+            'wink-blocks/winkaccount',
+            'wink-blocks/winkitinerary',
+            'wink-blocks/winkitineraryform',
+            'wink-blocks/winkcontent',
+        );
+        foreach ( $blocks as $block ) {
+            if ( has_block( $block, $post ) ) {
+                return true;
             }
-        } else if (is_admin() && empty(get_option('permalink_structure'))) {
-            echo '<div class="notice notice-info">
-            <img src="'.esc_url($this->pluginURL).'img/logo.png" alt="'.esc_html__('Wink logo',"wink2travel").'" width="100" style="margin-top: 10px;"><p><b>'.
-            esc_html__('Attention!', "wink2travel").
-            '</b> '.
-            esc_html__('the Wink plugin requires permalinks. Please disable plain permalinks',"wink2travel").
-            ' <a href="'.esc_url(admin_url('options-permalink.php')).'" title="'.esc_html__('Edit Permalinks',"wink2travel").'">'.
-            esc_html__('here',"wink2travel").
-            '</a> '.
-            esc_html__('and start using the plugin.',"wink2travel").
-            '.</p>
-            </div>';
+        }
+
+        $shortcodes = array( 'winklookup', 'winksearch', 'winkaccount', 'winkitinerary', 'winkitineraryform', 'winkcontent' );
+        foreach ( $shortcodes as $shortcode ) {
+            if ( has_shortcode( $post->post_content, $shortcode ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Outputs admin notices in the WordPress dashboard.
+     *
+     * Shows notices for: API authentication failures (from WinkApiClient), missing credentials,
+     * and disabled pretty permalinks. Only visible to administrators.
+     *
+     * @return void
+     */
+    function adminNotice(): void {
+        if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        // Auth failure notice — set by WinkApiClient when the Wink API rejects credentials.
+        $authError = get_transient( 'wink_auth_error' );
+        if ( $authError ) {
+            echo '<div class="notice notice-error"><p>'
+                . '<strong>' . esc_html__( 'Wink Plugin Error', 'wink2travel' ) . ':</strong> '
+                . esc_html__( 'Could not authenticate with the Wink API. Please verify your Client-ID and Client-Secret.', 'wink2travel' )
+                . ' <a href="' . esc_url( $this->settingsURL ) . '">'
+                . esc_html__( 'Review settings', 'wink2travel' )
+                . '</a></p></div>';
+            return;
+        }
+
+        if ( ! get_option( $this->clientIdKey, false ) ) {
+            echo '<div class="notice notice-info">'
+                . '<img src="' . esc_url( $this->pluginURL ) . 'img/logo.png" alt="' . esc_html__( 'Wink logo', 'wink2travel' ) . '" width="100" style="margin-top: 10px;">'
+                . '<p><b>' . esc_html__( 'Congratulations', 'wink2travel' ) . '</b> '
+                . esc_html__( 'on installing the official Wink Affiliate WordPress plugin.', 'wink2travel' )
+                . ' <a href="' . esc_url( $this->settingsURL ) . '" title="' . esc_html__( 'Wink settings', 'wink2travel' ) . '">'
+                . esc_html__( 'Click here', 'wink2travel' ) . '</a> '
+                . esc_html__( 'to add your Wink Client-ID and your Client-Secret', 'wink2travel' )
+                . '.</p></div>';
+        } elseif ( empty( get_option( 'permalink_structure' ) ) ) {
+            echo '<div class="notice notice-info">'
+                . '<img src="' . esc_url( $this->pluginURL ) . 'img/logo.png" alt="' . esc_html__( 'Wink logo', 'wink2travel' ) . '" width="100" style="margin-top: 10px;">'
+                . '<p><b>' . esc_html__( 'Attention!', 'wink2travel' ) . '</b> '
+                . esc_html__( 'the Wink plugin requires permalinks. Please disable plain permalinks', 'wink2travel' )
+                . ' <a href="' . esc_url( admin_url( 'options-permalink.php' ) ) . '" title="' . esc_html__( 'Edit Permalinks', 'wink2travel' ) . '">'
+                . esc_html__( 'here', 'wink2travel' ) . '</a> '
+                . esc_html__( 'and start using the plugin.', 'wink2travel' )
+                . '.</p></div>';
         }
     }
-    function addSettings( $wp_customize ) {
-        $shortcodes = array();
-        $allShortcodes = apply_filters( 'winkShortcodes', $shortcodes);
-        if (!empty($allShortcodes)) {
-            foreach ($allShortcodes as $key => $shortcodeData) {
-                if (!empty($shortcodeData['code'])) {
-                    $shortcodes[] = '['.$shortcodeData['code'].']';
+
+    /**
+     * Registers the Wink settings section and controls in the WordPress Customizer.
+     *
+     * All settings have sanitize_callback entries to prevent storing malicious data.
+     * The environment setting is restricted to the three known values.
+     *
+     * @param  WP_Customize_Manager $wp_customize The Customizer manager instance.
+     * @return void
+     */
+    function addSettings( WP_Customize_Manager $wp_customize ): void {
+        $shortcodes    = array();
+        $allShortcodes = apply_filters( 'winkShortcodes', $shortcodes );
+        if ( ! empty( $allShortcodes ) ) {
+            foreach ( $allShortcodes as $shortcodeData ) {
+                if ( ! empty( $shortcodeData['code'] ) ) {
+                    $shortcodes[] = '[' . $shortcodeData['code'] . ']';
                 }
             }
         }
+
         $wp_customize->add_section( $this->section, array(
-            'title'      => esc_html__( 'Wink Settings', "wink2travel" ),
-            'priority'   => 30,
-            'description' => '<p><img src="'.esc_url($this->pluginURL).'img/logo.png" alt="'.__('Wink logo',"wink2travel").'" width="100"></p>'.esc_html__('This plugin connects your site to your Wink account. Once you entered your Client-ID, you can start using the Wink elements either as a Gutenberg block or via the shortcodes below', "wink2travel" ).'<br>'.implode('<br>',$shortcodes)
+            'title'       => esc_html__( 'Wink Settings', 'wink2travel' ),
+            'priority'    => 30,
+            'description' => '<p><img src="' . esc_url( $this->pluginURL ) . 'img/logo.png" alt="' . esc_attr__( 'Wink logo', 'wink2travel' ) . '" width="100"></p>'
+                . esc_html__( 'This plugin connects your site to your Wink account. Once you entered your Client-ID, you can start using the Wink elements either as a Gutenberg block or via the shortcodes below', 'wink2travel' )
+                . '<br>' . implode( '<br>', $shortcodes ),
         ) );
 
-
-        $wp_customize->add_setting( $this->clientIdKey,array(
-            'type' => 'option'
-        ));
+        $wp_customize->add_setting( $this->clientIdKey, array(
+            'type'              => 'option',
+            'sanitize_callback' => 'sanitize_text_field',
+        ) );
         $wp_customize->add_control( $this->clientIdKey, array(
-            'label'      => esc_html__( 'Client-ID', "wink2travel" ),
-            'description' => esc_html__('You can find your Wink Client-ID in your Wink account. After entering your Client-ID start using Wink by adding the Wink Gutenberg blocks to your website.', "wink2travel"),
-            'section'    => $this->section,
+            'label'       => esc_html__( 'Client-ID', 'wink2travel' ),
+            'description' => esc_html__( 'You can find your Wink Client-ID in your Wink account. After entering your Client-ID start using Wink by adding the Wink Gutenberg blocks to your website.', 'wink2travel' ),
+            'section'     => $this->section,
         ) );
 
-        $wp_customize->add_setting( $this->clientSecretKey,array(
-            'type' => 'option'
-        ));
-        $wp_customize->add_control( $this->clientSecretKey, array(
-            'label'      => esc_html__( 'Client-Secret', "wink2travel" ),
-            'description' => esc_html__('You can find your Wink Client-Secret in your Wink account. After entering your Client-Secret and your Client-ID start using Wink by adding the Wink Gutenberg blocks to your website.', "wink2travel"),
-            'section'    => $this->section,
+        $wp_customize->add_setting( $this->clientSecretKey, array(
+            'type'              => 'option',
+            'sanitize_callback' => 'sanitize_text_field',
         ) );
-        
-        $wp_customize->add_setting( $this->environment,array(
-            'type' => 'option',
-            'default' => 'live'
-        ));
+        $wp_customize->add_control( $this->clientSecretKey, array(
+            'label'       => esc_html__( 'Client-Secret', 'wink2travel' ),
+            'description' => esc_html__( 'You can find your Wink Client-Secret in your Wink account. After entering your Client-Secret and your Client-ID start using Wink by adding the Wink Gutenberg blocks to your website.', 'wink2travel' ),
+            'section'     => $this->section,
+        ) );
+
+        $wp_customize->add_setting( $this->environment, array(
+            'type'              => 'option',
+            'default'           => 'production',
+            'sanitize_callback' => function ( string $value ): string {
+                $allowed = array( 'production', 'staging', 'development' );
+                return in_array( $value, $allowed, true ) ? $value : 'production';
+            },
+        ) );
         $wp_customize->add_control( $this->environment, array(
-            'type' => 'select',
-            'label'      => esc_html__( 'Environment', "wink2travel" ),
-            'description' => esc_html__('Switch between environments. Use with caution and only if instructed by the Wink team.', "wink2travel"),
-            'section'    => $this->section,
-            'choices' => array(
-                'production' => esc_html__( 'Live' ),
-                'staging' => esc_html__( 'Staging' ),
-                'development' => esc_html__( 'Development' )
+            'type'        => 'select',
+            'label'       => esc_html__( 'Environment', 'wink2travel' ),
+            'description' => esc_html__( 'Switch between environments. Use with caution and only if instructed by the Wink team.', 'wink2travel' ),
+            'section'     => $this->section,
+            'choices'     => array(
+                'production'  => esc_html__( 'Live' ),
+                'staging'     => esc_html__( 'Staging' ),
+                'development' => esc_html__( 'Development' ),
             ),
         ) );
-        
     }
 
-    function clearwinkCache() {
+    /**
+     * Deletes all Wink cached data. Called when Customizer settings are saved.
+     *
+     * Clears the bearer token transient, layout data transient, and auth error transient.
+     * Also removes legacy wp_options cache entries from versions prior to 1.4.21.
+     * Restricted to users with the manage_options capability.
+     *
+     * @return void
+     */
+    function clearwinkCache(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        delete_transient( 'wink_bearer_token' );
+        delete_transient( 'wink_layouts_data' );
+        delete_transient( 'wink_auth_error' );
+        // Legacy cleanup: these wp_options entries were replaced by transients in v1.4.21+.
         delete_option( 'winkData' );
         delete_option( 'winkdataTime' );
         delete_option( 'winkcontentTime' );
         delete_option( 'winkcontentBearer' );
     }
 
-    function gutenbergBlockCategory($categories, $post) {
-            return array_merge(
-                $categories,
+    /**
+     * Registers the "Wink Blocks" category in the Gutenberg block inserter.
+     *
+     * @param  array $categories       Existing block categories.
+     * @param  mixed $block_editor_ctx The current block editor context (WP_Post or WP_Block_Editor_Context).
+     * @return array Categories with the Wink category appended.
+     */
+    function gutenbergBlockCategory( array $categories, $block_editor_ctx ): array {
+        return array_merge(
+            $categories,
+            array(
                 array(
-                    array(
-                        'slug' => "wink2travel".'-blocks',
-                        'title' => esc_html__( 'Wink Blocks', "wink2travel" ),
-                    ),
-                )
-            );
-    }
-}
-
-$wink = new wink();
-
-class winkCore {
-    function __construct() {
-
-    }
-    static function environmentURL($target, $environment) {
-    //    error_log('Wink - target: '.$target);
-    //    error_log('Wink - environment: '.$environment);
-        $environments = array(
-            'js' => array(
-                'staging' => 'https://staging-elements.wink.travel',
-                'development' => 'https://dev.traveliko.com:8011',
-                'production' => 'https://elements.wink.travel'
-            ),
-            'json' => array(
-                'staging' => 'https://staging-iam.wink.travel',
-                'development' => 'https://dev.traveliko.com:9000',
-                'production' => 'https://iam.wink.travel'
-            ),
-            'api' => array(
-                'staging' => 'https://staging-api.wink.travel',
-                'development' => 'https://dev.traveliko.com:8443',
-                'production' => 'https://api.wink.travel'
+                    'slug'  => 'wink2travel-blocks',
+                    'title' => esc_html__( 'Wink Blocks', 'wink2travel' ),
+                ),
             )
         );
-        return $environments[$target][$environment];
     }
 }
 
-if (!empty(get_option('winkClientId', false))) {
-    require_once('includes/elementHandler.php'); // Handles all Wink Elements (Only load it if the client id is present)
+// Instantiation is skipped when WINK_TESTING is defined so that test files can
+// load this file (to access class definitions) without triggering hook registration.
+if ( ! defined( 'WINK_TESTING' ) ) {
+    $wink = new wink();
+}
+
+/**
+ * Utility class providing environment-aware URL resolution for Wink API services.
+ *
+ * All methods are static. This class is never instantiated.
+ */
+class winkCore {
+    /**
+     * Returns the base URL for a given Wink service in the specified deployment environment.
+     *
+     * The three service targets map to different Wink backend systems:
+     * - 'js'   — CDN for the Wink Web Component JavaScript and CSS bundles
+     * - 'json' — IAM (Identity & Access Management) server for OAuth2 token requests
+     * - 'api'  — REST API server for inventory and layout data
+     *
+     * Production is the default for any unrecognised environment string, which prevents
+     * a typo in the environment setting from causing a complete outage.
+     *
+     * @param  string $target      The service type: 'js', 'json', or 'api'.
+     * @param  string $environment The deployment environment. Expected: 'production', 'staging', or 'development'.
+     * @return string The base URL for the requested service and environment.
+     * @throws \InvalidArgumentException If $target is not a recognised service name.
+     */
+    static function environmentURL( string $target, string $environment ): string {
+        $urls = match ( $environment ) {
+            'staging' => array(
+                'js'   => 'https://staging-elements.wink.travel',
+                'json' => 'https://staging-iam.wink.travel',
+                'api'  => 'https://staging-api.wink.travel',
+            ),
+            'development' => array(
+                'js'   => 'https://dev.traveliko.com:8011',
+                'json' => 'https://dev.traveliko.com:9000',
+                'api'  => 'https://dev.traveliko.com:8443',
+            ),
+            default => array(
+                'js'   => 'https://elements.wink.travel',
+                'json' => 'https://iam.wink.travel',
+                'api'  => 'https://api.wink.travel',
+            ),
+        };
+
+        if ( ! array_key_exists( $target, $urls ) ) {
+            throw new \InvalidArgumentException(
+                "Wink: unknown environment target '{$target}'. Expected one of: js, json, api."
+            );
+        }
+
+        return $urls[ $target ];
+    }
+}
+
+// During testing WINK_TESTING is defined, so we skip this conditional entirely.
+// The test bootstrap loads elementHandler.php directly instead.
+if ( ! defined( 'WINK_TESTING' ) ) {
+    if ( ! empty( get_option( WINK_CLIENT_ID_OPTION, false ) ) ) {
+        require_once 'includes/elementHandler.php';
+    }
 }


### PR DESCRIPTION
## Summary

Complete overhaul of the Wink affiliate plugin from an unmaintained codebase to a professionally tested, security-hardened PHP 8 plugin ready for WordPress.org release.

- **PHP 8 modernization** — typed properties, `match` expressions, constructor property promotion, return type declarations throughout
- **Security hardening** — `sanitize_callback` on all Customizer settings, capability check on cache-clear, centralized sanitized editor-context detection, escape-late XSS prevention, single constant for the option key
- **Performance** — WordPress Transients API replaces manual option-based caching, `WINK_CACHE_TTL` constant, conditional script loading (Wink JS skipped on pages with no Wink blocks)
- **Refactoring** — `WinkApiClient` extracted from `winkcontent.php`, `WinkException` hierarchy introduced, `gutenbergBlockRegistration()` moved from 5 identical copies into the base class, `$GLOBALS` replaced with a static class property
- **Unit test suite** — 57 tests / 102 assertions, all green, covering `WinkApiClient`, cache-clear access control, content rendering, URL resolution, and the exception hierarchy
- **CI** — GitHub Actions workflow running on PHP 8.1 / 8.2 / 8.3 on every push and PR

## Test plan

- [ ] `composer install && ./vendor/bin/phpunit` — all 57 tests pass locally
- [ ] CI workflow triggers on this PR and goes green on all three PHP versions
- [ ] Gutenberg editor: each of the 6 blocks renders a readable escaped placeholder in the editor preview
- [ ] Front end: each block renders its `<wink-*>` custom element tag correctly
- [ ] Shortcodes: `[winklookup]`, `[winkcontent layoutId="xxx"]` etc. render on the front end
- [ ] Customizer: saving credentials clears the bearer-token and layout-data transients
- [ ] Wrong credentials: admin error banner appears in WP admin, front end shows nothing
- [ ] Page without Wink blocks: confirm `elements.js` is **not** in page source (conditional loading)
- [ ] WPBakery / Elementor / Avada: smoke-test one element per builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)